### PR TITLE
大画面でカレンダーが大きくなりすぎないようにする

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,13 @@ const events = articles.map((article) => ({
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-  <title>Vim 駅伝</title>
+    <title>Vim 駅伝</title>
+    <style>
+      body {
+        width: min(1000px, 80%);
+        margin: 0 auto;
+      }
+    </style>
   </head>
   <body>
     <h1>Vim 駅伝</h1>


### PR DESCRIPTION
十分に大きな画面でキャンペーンページを開くと，カレンダーが画面を占領してしまうため，最大幅を1000px にしました．
小さめの画面で開くと横幅の８０％をカレンダーが占領し，ほどほどの余白をつくります．