### PR TITLE
ビルドエラーの解決

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const articles = content.articles;
         <h1>Vim 駅伝</h1>
         <div class="tw-c-section hidden md:block">
           <h2>スケジュール</h2>
-          <Calendar articles={articles} client:load />
+          <Calendar articles={articles} client:only="react" />
         </div>
         <div class="tw-c-section">
           <h2>記事一覧</h2>


### PR DESCRIPTION
React コンポーネント内で `styled` を使うには `client:only` とする必要がありそうだったため、そのように対応しました。

関連 issue: https://github.com/withastro/astro/issues/4432
`client:only` について: https://docs.astro.build/en/reference/directives-reference/#clientonly

（PR 時点でもビルドが走るようにしたほうがよさそう）