### PR TITLE
日付ラベルが見えなくなる問題の解消

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,3 +51,8 @@ const articles = content.articles;
     @apply text-blue-600;
   }
 </style>
+<style is:global>
+  div.fc-daygrid-day-top {
+    @apply relative z-10;
+  }
+</style>


### PR DESCRIPTION
ドキュメントにて問題のクラスに対してCSSを当てて良いと明記されていたため、index.astor内へCSSルールを追加いたしました。
参照：https://fullcalendar.io/docs/css-customization
