### PR TITLE
RSS feed 追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import react from "@astrojs/react";
 import tailwind from "@astrojs/tailwind";
 
 export default defineConfig({
+  site: "https://vim-jp.org",
   base: "/ekiden",
   integrations: [react(), tailwind()],
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^2.0.2",
+    "@astrojs/rss": "^2.1.1",
     "@astrojs/tailwind": "^3.0.1",
     "@emotion/react": "^11.0.0-rc.0",
     "@emotion/styled": "^11.10.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@astrojs/react': ^2.0.2
+  '@astrojs/rss': ^2.1.1
   '@astrojs/tailwind': ^3.0.1
   '@emotion/react': ^11.0.0-rc.0
   '@emotion/styled': ^11.10.6
@@ -25,6 +26,7 @@ specifiers:
 
 dependencies:
   '@astrojs/react': 2.0.2_3xleytyzprlgycb2ded54tx72i
+  '@astrojs/rss': 2.1.1
   '@astrojs/tailwind': 3.0.1_hf2kjfio2dr6w52rh4mpociq2u
   '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
   '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
@@ -130,6 +132,13 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@astrojs/rss/2.1.1:
+    resolution: {integrity: sha512-3BpCqyCmVWfrGqyc1YXUQf7O3QjORYNmvxzeKvp0E+7KGiKj8ckRzwj90xGYjbKcb/BwKfzYgek4+BrZ1aqQtA==}
+    dependencies:
+      fast-xml-parser: 4.1.3
+      kleur: 4.1.5
     dev: false
 
   /@astrojs/tailwind/3.0.1_hf2kjfio2dr6w52rh4mpociq2u:
@@ -1986,6 +1995,13 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-xml-parser/4.1.3:
+    resolution: {integrity: sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
+
   /fastq/1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
@@ -3735,6 +3751,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
+
+  /strnum/1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
 
   /stylis/4.1.3:
     resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,0 +1,24 @@
+import rss from "@astrojs/rss";
+import dayjs from "dayjs";
+import content from "../content.json";
+
+export async function get(context) {
+  const today = dayjs();
+  const articles = content.articles
+    .filter((article) => today >= dayjs(article.date))
+    .sort((a, b) => dayjs(b.date) - dayjs(a.date))
+    .slice(0, 10);
+
+  return rss({
+    title: "Vim 駅伝",
+    description:
+      "「Vim 駅伝」とは、Vim に関する記事を持ち回りで執筆する企画です。",
+    site: context.site,
+    items: articles.map((article) => ({
+      title: article.title,
+      description: `By ${article.author}`,
+      pubDate: article.date,
+      link: article.url,
+    })),
+  });
+}


### PR DESCRIPTION
RSS feed を追加してみました。

- `content.json` をもとに本日以前の記事を新しい順に10件 `rss.xml` に生成します。
    - URLは、投稿された記事へのURLになります。
    - 記事の `description` は、一律 `by (author)` にしてあります。
- `index.astro` などへの RSS アイコンの追加などはひとまずしていないです。

サンプルのxmlファイルです。

![image](https://user-images.githubusercontent.com/1638500/222072085-7c898088-3f6c-49eb-acd2-6b0217fe4b78.png)


github pages へのデプロイって、現状、日次で動いていたりしますでしょうか。


#25 