### PR TITLE
Fix to hide overflow content from the calendar cells

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -17,6 +17,9 @@ const OverrideCalendarStyle = styled.div`
   .fc-bg-event {
     opacity: 1;
   }
+  .fc-daygrid-bg-harness {
+    overflow: hidden;
+  }
 `;
 
 const REGISTRATION_LINK_DISPLAY_DAYS = 30;


### PR DESCRIPTION
カレンダーのセル内からはみ出す内容を隠すようにする（下図の赤矢印で示している部分）。
![vim-ekiden-overflow](https://user-images.githubusercontent.com/345349/222174213-878ac649-b365-45fd-ad58-16b2850ce2f3.png)

FullCalendarもAstoroも、お作法ナンモワカラン状態で修正したので、万一、スタイル当てる位置がおかしかったらすみません・