### PR TITLE
Change REGISTRATION_LINK_DISPLAY_DAYS to 60

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -19,7 +19,7 @@ const OverrideCalendarStyle = styled.div`
   }
 `;
 
-const REGISTRATION_LINK_DISPLAY_DAYS = 30;
+const REGISTRATION_LINK_DISPLAY_DAYS = 60;
 /**
  * Vim 駅伝対象日の日付を YYYY-MM-DD 形式で返す。
  * ただし 本日から REGISTRATION_LINK_DISPLAY_DAYS 以内の日付に限る。


### PR DESCRIPTION
エントリー可能な日が週 3 日なので、30 日だと 12,13 日分程度しかエントリーができない。
もっと先まで埋まっても大丈夫なように、60 日先までエントリー可能にする。

(※カレンダーを使わずに Issue に直接日付を入れれば、何日先でもエントリーは可能ではある)