### PR TITLE
[Update] Update ekiden base-color.

### DIFF
--- a/src/components/Article.astro
+++ b/src/components/Article.astro
@@ -17,7 +17,7 @@ const published = today >= dayjs(date);
 ---
 
 <div
-  class="mb-4 w-full p-2 rounded-lg bg-white grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4"
+  class="mb-4 w-full p-2 rounded-lg grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4"
 >
   <p class="text-gray-700 text-base mb-1 break-words truncate">
     {date}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -50,7 +50,7 @@ const Calendar = (props: Props) => {
       url: article.url,
       date: article.date,
       display: "background",
-      backgroundColor: "#d0f5dd",
+      backgroundColor: "rgb(108, 154, 157, 0.75)",
 
       // extended props
       author: article.author,
@@ -64,7 +64,7 @@ const Calendar = (props: Props) => {
       eventMap.set(date, {
         date,
         display: "background",
-        backgroundColor: "#f7e3e3",
+        backgroundColor: "#edc7a1",
 
         // extended props
         registered: false,
@@ -90,7 +90,7 @@ const Calendar = (props: Props) => {
             )}
           </div>
           <div>
-            <span style={{ color: "#444444" }}>
+            <span style={{ color: "#111111" }}>
               {arg.event.extendedProps.author}
             </span>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,8 +16,8 @@ const articles = content.articles;
   </head>
   <body>
     <main>
+      <h1>Vim 駅伝</h1>
       <div class="tw-c-container">
-        <h1>Vim 駅伝</h1>
         <div class="tw-c-section">
           <h2>スケジュール</h2>
           <Calendar articles={articles} client:only="react" />
@@ -32,23 +32,28 @@ const articles = content.articles;
 </html>
 
 <style>
+  body {
+    background-color: #f6f7f8;
+  }
   main {
-    @apply flex justify-center my-10 mx-5;
+    @apply flex justify-center items-center flex-col p-0 m-0;
   }
   div.tw-c-container {
-    @apply max-w-4xl flex-1;
+    @apply max-w-4xl flex-1 px-4;
   }
   div.tw-c-section {
     @apply py-5;
   }
   h1 {
-    @apply text-4xl font-bold;
+    @apply text-4xl font-bold py-16 w-full text-center;
+    color: #2c3e50;
+    background-color: #6c9a9d;
   }
   h2 {
     @apply text-2xl font-bold my-1;
   }
   a {
-    @apply text-blue-600;
+    @apply text-blue-500;
   }
 </style>
 <style is:global>
@@ -63,6 +68,10 @@ const articles = content.articles;
   }
   div.fc-bg-event {
     @apply p-2;
+  }
+  th.fc-day {
+    @apply text-white;
+    background-color: #2c3e50;
   }
   th.fc-day-sun {
     @apply bg-red-500 text-white;


### PR DESCRIPTION
1. vim-jp.slackに上がっていた[Vim駅伝カラー](https://vim-jp.slack.com/archives/C04N5HV5YTY/p1677759132666349)を適用（背景色及び文字色）。
2. タイトル部分のデザインを修正（ブログのトップっぽいデザインに修正）
3. 記事一覧の背景色を排除（bg-whiteが適用されていたため)

イメージはこんな感じです。
![image](https://user-images.githubusercontent.com/40669/222582236-23eeedff-3d70-4d08-b823-a8e621ad0b8e.png)
![image](https://user-images.githubusercontent.com/40669/222582577-dc887a08-0be9-43e6-831c-261b6c566915.png)
