### PR TITLE
Auto deploy on publish day

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-  
+  schedule:
+    - cron: '0 15 * * 0,2,4'  # 日火木 15:00 UTC == 月水金 0:00 JST
+
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
URL が事前登録されていた場合に、

- リストのタイトルにリンクを追加
- RSS にエントリーを追加

を行うため、公開日の月水金の 0 時(JST) に自動でデプロイを行う。

Closes #25