### PR TITLE
本文の書体を総称ファミリーで指定

### DIFF
--- a/src/components/Article.astro
+++ b/src/components/Article.astro
@@ -93,6 +93,7 @@ const published = dayjs() >= dayjs(date);
 
   .date {
     display: flex;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
     font-size: var(--date-fs);
     min-width: calc(var(--date-r) * 2);
     min-height: calc(var(--date-r) * 2);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,6 +51,7 @@ const articles = content.articles;
   @import url("https://fonts.googleapis.com/css2?family=Kaushan+Script&family=Yuji+Syuku&display=swap");
   section {
     padding: 20px;
+    padding-top: 5px;
     color: #666;
     margin-top: 50px;
     border: 5px solid #666;
@@ -58,7 +59,7 @@ const articles = content.articles;
     background: rgba(244, 244, 244, 1);
   }
   body {
-    font-family: "Kaushan Script", "Yuji Syuku", serif;
+    font-family: sans-serif;
     background-color: #f6f7f8;
   }
   main {
@@ -72,12 +73,14 @@ const articles = content.articles;
   }
   h1 {
     @apply text-4xl py-3 w-full text-center;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
     background: #477745;
     color: #efefef;
     box-shadow: 1px 0px 2px black;
   }
   h2 {
-    @apply text-2xl font-bold my-1;
+    @apply text-2xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
   }
   a {
     @apply text-blue-500;


### PR DESCRIPTION
現在使用している書体が読みづらい（特に欧文）という意見が多かったため、デザインに大きく影響する「Vim 駅伝」ヘッダや見出し、日付の書体だけ現状を維持し、それ以外の本文の書体を総称ファミリーの `sans-serif` としました。

また、フォントの変更によって概要説明欄のまとまりが悪くなったように感じられたため、
よりメリハリをつけるため余白を若干調整しています。

sans-serif を Noto Sans CJK JP で表示するよう設定している私のブラウザ上だと、以下のように表示されます。
 
![ekiden-top](https://user-images.githubusercontent.com/48883418/229135141-c2e2ed5a-5353-4fd8-a5fc-4cd348441952.jpg)
