### PR TITLE
アーカイブページの追加

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,26 @@
+---
+import HeaderLink from "./HeaderLink.astro";
+const { slug } = Astro.props;
+---
+
+<div class="header">
+  <h1><a href="/ekiden/">Vim 駅伝</a></h1>
+  <nav class="flex justify-center pb-2">
+    <HeaderLink slug={slug} href="/">トップページ</HeaderLink>
+    <HeaderLink slug={slug} href="/archive/">アーカイブ</HeaderLink>
+  </nav>
+</div>
+
+<style>
+  @import url("https://fonts.googleapis.com/css2?family=Kaushan+Script&family=Yuji+Syuku&display=swap");
+  .header {
+    @apply w-full;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+    background: #477745;
+    color: #efefef;
+    box-shadow: 1px 0px 2px black;
+  }
+  h1 {
+    @apply text-4xl py-3 text-center;
+  }
+</style>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -1,0 +1,12 @@
+---
+const { slug, href } = Astro.props;
+---
+
+<span class="px-4">
+  {slug === href
+  ?
+    <span class="underline"><slot/></span>
+  :
+    <a href={"/ekiden" + href}><slot/></a>
+  }
+</span>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,36 @@
+---
+import Header from "../components/Header.astro";
+
+const {title, slug} = Astro.props;
+
+---
+
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <slot name="head"/>
+    <title>{title}</title>
+  </head>
+  <body>
+    <main>
+      <Header slug={slug}/>
+      <div class="max-w-4xl flex-1 px-4">
+        <slot/>
+      </div>
+    </main>
+  </body>
+</html>
+
+<style>
+  @import url("https://fonts.googleapis.com/css2?family=Kaushan+Script&family=Yuji+Syuku&display=swap");
+  body {
+    font-family: sans-serif;
+    background-color: #f6f7f8;
+  }
+
+  main {
+    @apply flex justify-center items-center flex-col p-0 m-0;
+  }
+</style>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,0 +1,53 @@
+---
+import dayjs from "dayjs";
+import Articles from "../components/Articles.astro";
+import Header from "../components/Header.astro";
+import content from "../content.json";
+import Base from "../layouts/Base.astro";
+
+const slug = "/archive/"
+
+const articles = content.articles
+  .sort((a, b) => (dayjs(a.date).unix() - dayjs(b.date).unix()))
+  .filter((article) => (
+    dayjs(article.date) <= dayjs() && article.url !== null
+  ))
+  .map(
+    (article, index) => ({
+      index: index + 1,
+      shortDate: dayjs(article.date).format("M/D"),
+      ...article
+      })
+  );
+
+---
+
+<Base title="Vim 駅伝 - アーカイブ" slug="/archive/">
+  {articles.map((article) => (
+    <div class="w-full hover:shadow-md hover:bg-[#efefef]">
+      <a href={article.url}>
+        <div class="p-4">
+          <div class="flex items-center">
+            <div class="rounded-full bg-[#477745] text-white w-16 h-16 flex items-center justify-center mr-4">
+              <div class="text-center">
+                <div class="text-lg font-bold">#{article.index}</div>
+                <div>{article.shortDate}</div>
+              </div>
+            </div>
+            <div class="text-gray-700">
+              <h2 class="text-lg font-bold mb-1">{article.title}</h2>
+              <p class="text-sm">{article.author}</p>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+  ))}
+</Base>
+
+<style>
+  h1 {
+    @apply text-4xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,54 +1,44 @@
 ---
 import Articles from "../components/Articles.astro";
 import content from "../content.json";
+import Base from "../layouts/Base.astro";
 
 const articles = content.articles;
 ---
 
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="generator" content={Astro.generator} />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="RSS2.0"
-      href={`${import.meta.env.BASE_URL}rss.xml`}
-    />
-    <title>Vim 駅伝</title>
-  </head>
-  <body>
-    <main>
-      <h1>Vim 駅伝</h1>
-      <div class="tw-c-container">
-        <section>
-          <h2>Vim 駅伝とは</h2>
-          <p>
-            Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。
-            GitHub のアカウントさえあれば誰でも投稿できます。
-            小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、
-            Vim
-            またはテクノロジーに関連していればどんな些細な内容でもかまいません。
-            皆さんの手で、Vim 駅伝を盛り上げていきましょう！
-          </p>
-          <h2>注意事項</h2>
-          <ul>
-            <li>
-              個人攻撃や差別的な内容を含む記事、公序良俗に反する不適切な記事の投稿を禁止します。
-              明らかに不適切と判断された記事については、GitHub
-              経由での通告のもと本ページからリンクを削除する場合があります。
-            </li>
-          </ul>
-        </section>
-        <Articles articles={articles} />
-      </div>
-    </main>
-  </body>
-</html>
+<Base title="Vim 駅伝" slug="/">
+  {/* head tag 内に記述する要素は slot="head" を指定する */}
+  <link
+    slot="head"
+    rel="alternate"
+    type="application/rss+xml"
+    title="RSS2.0"
+    href={`${import.meta.env.BASE_URL}rss.xml`}
+  />
+
+  <section>
+    <h2>Vim 駅伝とは</h2>
+    <p>
+      Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。
+      GitHub のアカウントさえあれば誰でも投稿できます。
+      小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、
+      Vim
+      またはテクノロジーに関連していればどんな些細な内容でもかまいません。
+      皆さんの手で、Vim 駅伝を盛り上げていきましょう！
+    </p>
+    <h2>注意事項</h2>
+    <ul>
+      <li>
+        個人攻撃や差別的な内容を含む記事、公序良俗に反する不適切な記事の投稿を禁止します。
+        明らかに不適切と判断された記事については、GitHub
+        経由での通告のもと本ページからリンクを削除する場合があります。
+      </li>
+    </ul>
+  </section>
+  <Articles articles={articles} />
+</Base>
 
 <style>
-  @import url("https://fonts.googleapis.com/css2?family=Kaushan+Script&family=Yuji+Syuku&display=swap");
   section {
     padding: 20px;
     padding-top: 5px;
@@ -57,26 +47,6 @@ const articles = content.articles;
     border: 5px solid #666;
     border-radius: 30px;
     background: rgba(244, 244, 244, 1);
-  }
-  body {
-    font-family: sans-serif;
-    background-color: #f6f7f8;
-  }
-  main {
-    @apply flex justify-center items-center flex-col p-0 m-0;
-  }
-  div.tw-c-container {
-    @apply max-w-4xl flex-1 px-4;
-  }
-  div.tw-c-section {
-    @apply py-5;
-  }
-  h1 {
-    @apply text-4xl py-3 w-full text-center;
-    font-family: "Kaushan Script", "Yuji Syuku", serif;
-    background: #477745;
-    color: #efefef;
-    box-shadow: 1px 0px 2px black;
   }
   h2 {
     @apply text-2xl font-bold mt-4 mb-2;


### PR DESCRIPTION
トップページからは前後1ヶ月の記事しか表示されないようになっているはずなので、公開済みのすべての記事を確認できるアーカイブページを追加しました。
アーカイブページでは記事に通し番号をつけることで、何番目の記事になるかもすぐに分かるようになっています。

また、アーカイブページへ遷移できるようにするため、ヘッダに相当する場所にトップページとアーカイブページへのリンクを追加しました。

デザインは適当です。

![スクリーンショット 2023-04-01 23 13 35](https://user-images.githubusercontent.com/48883418/229294407-0b381261-d27e-4b3d-bb0e-0490cc347986.png)