### PR TITLE
未公開記事のトップページのリンクを無効化

### DIFF
--- a/src/components/Article.astro
+++ b/src/components/Article.astro
@@ -27,7 +27,7 @@ const published = dayjs() >= dayjs(date);
       </div>
     )
   }
-  <a href={published ? url : opened ? url : "#"} class="article">
+  <a href={(published || opened) ? url : undefined} class="article">
     <div class:list={["date", { opened, published }]}>
       {dayjs(date).date()}日
     </div>


### PR DESCRIPTION
トップページにおいて、公開前の記事が vim-jp トップページへのリンクになってしまうのを修正しました。

ホバー時に円が拡大する効果は残しています。
