### PR TITLE
新着記事へのリンクを冒頭に追加

### DIFF
--- a/src/components/Article.astro
+++ b/src/components/Article.astro
@@ -19,7 +19,7 @@ const { title, date, author, url, firstDay, opened } = Astro.props;
 const published = dayjs() >= dayjs(date);
 ---
 
-<div class="container">
+<div class="container" id={`article-${date}`}>
   {
     firstDay && (
       <div class="month">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -5,7 +5,7 @@ type Props = { title: string; slug: string };
 const { title, slug } = Astro.props;
 ---
 
-<html lang="ja">
+<html lang="ja" class="scroll-smooth">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,6 @@ const newestArticle = content.articles
   .filter((article) => dayjs(article.date) <= dayjs() && article.url !== null)
   .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
   .pop();
-
 ---
 
 <Base title="Vim 駅伝" slug="/">
@@ -26,7 +25,10 @@ const newestArticle = content.articles
   <section class="py-4">
     <h2>Vim 駅伝とは</h2>
     <p>
-      Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。 GitHub のアカウントさえあれば誰でも投稿できます。 小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、 Vim またはテクノロジーに関連していればどんな些細な内容でもかまいません。
+      Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。
+      GitHub のアカウントさえあれば誰でも投稿できます。
+      小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、
+      Vim またはテクノロジーに関連していればどんな些細な内容でもかまいません。
       皆さんの手で、Vim 駅伝を盛り上げていきましょう！
     </p>
     <h2>注意事項</h2>
@@ -39,14 +41,15 @@ const newestArticle = content.articles
     </ul>
   </section>
   <section class="news">
-    {newestArticle &&
-      <p>
-        <b>News</b>:
-        {dayjs(newestArticle.date).format("M/D")}
-        の記事
-        「<a href=`#article-${newestArticle.date}`>{newestArticle.title}</a>」
-        が公開されました！
-      </p>
+    {
+      newestArticle && (
+        <p>
+          <b>News</b>:{dayjs(newestArticle.date).format("M/D")}
+          の記事 「
+          <a href={`#article-${newestArticle.date}`}>{newestArticle.title}</a>」
+          が公開されました！
+        </p>
+      )
     }
   </section>
   <Articles articles={articles} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,16 @@
 ---
+import dayjs from "dayjs";
 import Articles from "../components/Articles.astro";
 import content from "../content.json";
 import Base from "../layouts/Base.astro";
 
 const articles = content.articles;
+
+const newestArticle = content.articles
+  .filter((article) => dayjs(article.date) <= dayjs() && article.url !== null)
+  .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
+  .pop();
+
 ---
 
 <Base title="Vim 駅伝" slug="/">
@@ -16,13 +23,10 @@ const articles = content.articles;
     href={`${import.meta.env.BASE_URL}rss.xml`}
   />
 
-  <section>
+  <section class="py-4">
     <h2>Vim 駅伝とは</h2>
     <p>
-      Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。
-      GitHub のアカウントさえあれば誰でも投稿できます。
-      小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、
-      Vim またはテクノロジーに関連していればどんな些細な内容でもかまいません。
+      Vimmerを中心に技術的なコンテンツを持ち寄り、リレー形式で記事をリンクする営みです。 GitHub のアカウントさえあれば誰でも投稿できます。 小さなノウハウ、ちょっとした気づき、作ったプラグイン、開発の苦労話など、 Vim またはテクノロジーに関連していればどんな些細な内容でもかまいません。
       皆さんの手で、Vim 駅伝を盛り上げていきましょう！
     </p>
     <h2>注意事項</h2>
@@ -34,16 +38,30 @@ const articles = content.articles;
       </li>
     </ul>
   </section>
+  <section class="news">
+    {newestArticle &&
+      <p>
+        <b>News</b>:
+        {dayjs(newestArticle.date).format("M/D")}
+        の記事
+        「<a href=`#article-${newestArticle.date}`>{newestArticle.title}</a>」
+        が公開されました！
+      </p>
+    }
+  </section>
   <Articles articles={articles} />
 </Base>
+
 <style>
   section {
-    padding: 20px;
-    padding-top: 5px;
     color: #666;
-    margin-top: 50px;
-    border: 5px solid #666;
-    border-radius: 30px;
+    background: rgba(244, 244, 244, 1);
+  }
+  .news {
+    margin-top: 10px;
+    padding: 20px;
+    border: 3px solid #666;
+    border-radius: 10px;
     background: rgba(244, 244, 244, 1);
   }
   h2 {


### PR DESCRIPTION
新着記事のタイトルをトップに表示し、新着記事へのリンクを冒頭に追加しました。
それに伴ってレイアウトを少し変更しています。

記事のリンク先に直接飛ぶのではなく、Vim 駅伝トップページの特定の位置までスクロールするようにしています。

https://user-images.githubusercontent.com/48883418/232082893-e4b1450c-8848-450e-891f-ffc07b236de4.mov

