### PR TITLE
参加方法の説明を追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,6 +31,18 @@ const newestArticle = content.articles
       Vim またはテクノロジーに関連していればどんな些細な内容でもかまいません。
       皆さんの手で、Vim 駅伝を盛り上げていきましょう！
     </p>
+    <h2>参加方法</h2>
+    <p>
+      本ページの下のスケジュールのうち、「募集中」となっている日付が登録可能です。好きな日を選んで「参加登録」をクリックしてください。
+      すると GitHub の issue 作成ページに遷移しますので、タイトル等を埋め issue
+      を作成すれば登録完了です。
+    </p>
+    <p>
+      詳しくは<a
+        href="https://thinca.hatenablog.com/entry/vim-ekiden-is-launched"
+        >Vim 駅伝初日の記事</a
+      >を参照してください。
+    </p>
     <h2>注意事項</h2>
     <ul>
       <li>


### PR DESCRIPTION
参加方法が記されている場所への誘導がトップページになかったため、簡単な説明を追加しました。
詳細は thinca さんの記事に譲っています。