### PR TITLE
[Update] 走者一覧ページの追加及び、走者ページのデザイン変更

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ const { slug } = Astro.props;
   <nav>
     <HeaderLink slug={slug} href="/">トップページ</HeaderLink>
     <HeaderLink slug={slug} href="/archive/">アーカイブ</HeaderLink>
+    <HeaderLink slug={slug} href="/list">走者一覧</HeaderLink>
   </nav>
 </div>
 

--- a/src/pages/list.astro
+++ b/src/pages/list.astro
@@ -1,0 +1,20 @@
+---
+import content from "../content.json";
+import Base from "../layouts/Base.astro";
+const runners = content.articles.filter(
+  (article, index, self) =>
+    self.findIndex((element) => element.runner === article.runner) === index
+);
+---
+
+<Base title={`Vim 駅伝 - 走者一覧`} slug="/runner/">
+  <div class={"w-full flex flex-wrap"}>
+    {
+      runners.map((runner) => (
+        <div class={"p-4 my-2"}>
+          <a href={`/ekiden/runner/` + runner.githubUser}>{runner.runner}</a>
+        </div>
+      ))
+    }
+  </div>
+</Base>

--- a/src/pages/runner/[runner].astro
+++ b/src/pages/runner/[runner].astro
@@ -78,3 +78,9 @@ const runnersArticles = content.articles
     ))
   }
 </Base>
+<style>
+  h1 {
+    @apply text-3xl font-bold mt-4 mb-4 border-l-[24px] border-b pl-4;
+    border-color: #477745;
+  }
+</style>


### PR DESCRIPTION
1. 走者一覧ページを追加しました。

![image](https://github.com/vim-jp/ekiden/assets/40669/1dd64a45-ec9c-417c-8948-10cfe756750c)

2. 走者ページのデザインを変更しました
![image](https://github.com/vim-jp/ekiden/assets/40669/3c276515-c9f6-4192-b926-839afb0fda31)

要望等ありましたら、随時受け付けます。