### PR TITLE
fix: HeaderLink position is misaligned

### DIFF
--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -18,7 +18,8 @@ const { slug, href } = Astro.props;
 </span>
 
 <style>
-  span {
+  span,
+  a {
     @apply px-4 py-2;
   }
 </style>


### PR DESCRIPTION
ヘッダーの「トップーページ」と「アーカイブ」の位置が次の動画のようにページごとに少し異なっています。

https://github.com/vim-jp/ekiden/assets/61523777/1a8369e9-bfb5-49c4-8810-4442c7d2c632

修正後:

https://github.com/vim-jp/ekiden/assets/61523777/99b545b5-f9c4-4723-b52d-b4eae0432b36
