### PR TITLE
記事のURLを更新できるようにしたい．

### DIFF
--- a/.github/workflows/check-article.yml
+++ b/.github/workflows/check-article.yml
@@ -67,8 +67,8 @@ jobs:
               };
 
               const { data: issue } = await github.rest.issues.get(issuePayload);
-              if (issue.state === "closed") {
-                console.log("Issue はすでに閉じられています。");
+              if (issue.state === "closed" && issue.state_reason !== "completed") {
+                console.log("Issue はすでに投稿完了前に閉じられています。");
                 return;
               }
 

--- a/.github/workflows/update-article.yml
+++ b/.github/workflows/update-article.yml
@@ -34,7 +34,7 @@ jobs:
                deno --quiet run --allow-read --allow-write ./scripts/update-article.ts \
                --issueNumber '${{ github.event.issue.number }}' \
                --githubUser '${{ github.event.issue.user.login }}' \
-               ${{ github.event.action == 'closed' && 'delete' || '' }} \
+               ${{ github.event.issue.state == 'closed' && github.event.issue.state_reason != 'completed' && 'delete' || '' }} \
                2>> "${GITHUB_OUTPUT}"
           echo 'MESSAGE' >> "${GITHUB_OUTPUT}"
       - name: 'Push changes'

--- a/.github/workflows/update-article.yml
+++ b/.github/workflows/update-article.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     if: |
       contains(github.event.issue.labels.*.name, 'article') && (
-        github.event.issue.state == 'open' || github.event.action == 'closed'
+        github.event.issue.state == 'open'  || github.event.action == 'closed' || github.event.issue.state_reason == 'completed'
       )
     permissions:
       issues: 'write'


### PR DESCRIPTION
駅伝公開後 (つまり，ボットによって 'completed' としてissueが閉じされたあと)，issueの内容を変更した場合でも，その変更を追従できるようにしました．この手のGitHub Actionsはテストができないので，テストせずに投稿することになり恐縮ですが，よろしくお願いします．