### PR TITLE
Update astro.config.mjs to include trailing slash option

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,5 +12,6 @@ export default defineConfig({
   },
   redirects: {
     "/archive": "/ekiden/archives"
-  }
+  },
+  trailingSlash: 'always'
 });


### PR DESCRIPTION
## 問題
https://vim-jp.org/ekiden/rss.xmlが404になっている。

## 推測
astro.config.mjsにて定義されているbaseはtrailingSlashの影響を受けます。
defaultがignoreなので、alwaysに設定することでもしかすると改善するのではないか？と考えています。
https://docs.astro.build/en/reference/configuration-reference/#base
何故推測なのかというと、ローカルの開発環境では該当の問題が発生しないからです。