### PR TITLE
ランキングページの追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import svelte from "@astrojs/svelte";
 
 // https://astro.build/config
 import tailwind from "@astrojs/tailwind";
@@ -6,11 +7,11 @@ import tailwind from "@astrojs/tailwind";
 export default defineConfig({
   site: "https://vim-jp.org",
   base: "/ekiden",
-  integrations: [tailwind()],
-  server:{
-      host:true
+  integrations: [tailwind(), svelte()],
+  server: {
+    host: true,
   },
   redirects: {
-    "/archive": "/ekiden/archives"
-  }
+    "/archive": "/ekiden/archives",
+  },
 });

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.4",
+    "@astrojs/svelte": "^5.0.3",
     "@astrojs/tailwind": "^5.1.0",
     "astro": "^4.3.2",
+    "chart.js": "^4.4.1",
     "dayjs": "^1.11.10",
+    "svelte": "^4.2.10",
+    "svelte-chartjs": "^3.1.5",
     "tailwindcss": "^3.4.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,27 @@ dependencies:
   '@astrojs/rss':
     specifier: ^4.0.4
     version: 4.0.4
+  '@astrojs/svelte':
+    specifier: ^5.0.3
+    version: 5.0.3(astro@4.3.2)(svelte@4.2.10)(typescript@5.3.3)(vite@5.0.12)
   '@astrojs/tailwind':
     specifier: ^5.1.0
     version: 5.1.0(astro@4.3.2)(tailwindcss@3.4.1)
   astro:
     specifier: ^4.3.2
     version: 4.3.2(typescript@5.3.3)
+  chart.js:
+    specifier: ^4.4.1
+    version: 4.4.1
   dayjs:
     specifier: ^1.11.10
     version: 1.11.10
+  svelte:
+    specifier: ^4.2.10
+    version: 4.2.10
+  svelte-chartjs:
+    specifier: ^3.1.5
+    version: 3.1.5(chart.js@4.4.1)(svelte@4.2.10)
   tailwindcss:
     specifier: ^3.4.1
     version: 3.4.1
@@ -111,6 +123,23 @@ packages:
     dependencies:
       fast-xml-parser: 4.2.7
       kleur: 4.1.5
+    dev: false
+
+  /@astrojs/svelte@5.0.3(astro@4.3.2)(svelte@4.2.10)(typescript@5.3.3)(vite@5.0.12):
+    resolution: {integrity: sha512-6TUBRUxmsEczKPBT6oDUAfvzuFCmITuhZfKPT5ZtOOyj9XOVnEnj/Iobd3ajKUbpWNYX7qZVAd1KMkmJc1Nhsg==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      astro: ^4.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.1
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.10)(vite@5.0.12)
+      astro: 4.3.2(typescript@5.3.3)
+      svelte: 4.2.10
+      svelte2tsx: 0.6.27(svelte@4.2.10)(typescript@5.3.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+      - vite
     dev: false
 
   /@astrojs/tailwind@5.1.0(astro@4.3.2)(tailwindcss@3.4.1):
@@ -667,6 +696,10 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
+  /@kurkle/color@0.3.2:
+    resolution: {integrity: sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -800,6 +833,42 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.10)(vite@5.0.12):
+    resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
+    engines: {node: ^18.0.0 || >=20}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.10)(vite@5.0.12)
+      debug: 4.3.4
+      svelte: 4.2.10
+      vite: 5.0.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@4.2.10)(vite@5.0.12):
+    resolution: {integrity: sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==}
+    engines: {node: ^18.0.0 || >=20}
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.10)(vite@5.0.12)
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.5
+      svelte: 4.2.10
+      svelte-hmr: 0.15.3(svelte@4.2.10)
+      vite: 5.0.12
+      vitefu: 0.2.5(vite@5.0.12)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1427,6 +1496,13 @@ packages:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
     dev: false
 
+  /chart.js@4.4.1:
+    resolution: {integrity: sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==}
+    engines: {pnpm: '>=7'}
+    dependencies:
+      '@kurkle/color': 0.3.2
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -1478,6 +1554,16 @@ packages:
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
+    dev: false
+
+  /code-red@1.0.4:
+    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.5
+      acorn: 8.11.2
+      estree-walker: 3.0.3
+      periscopic: 3.1.0
     dev: false
 
   /color-convert@1.9.3:
@@ -1552,6 +1638,14 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1609,6 +1703,10 @@ packages:
     dev: false
     optional: true
 
+  /dedent-js@1.0.1:
+    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
+    dev: false
+
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -1619,6 +1717,11 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
+
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /default-browser-id@3.0.0:
     resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
@@ -2504,6 +2607,12 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /is-reference@3.0.2:
+    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
+    dependencies:
+      '@types/estree': 1.0.5
+    dev: false
+
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -2625,6 +2734,10 @@ packages:
       strip-bom: 3.0.0
     dev: false
 
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: false
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2651,6 +2764,12 @@ packages:
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    dev: false
+
+  /lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+    dependencies:
+      tslib: 2.5.2
     dev: false
 
   /lru-cache@5.1.1:
@@ -2818,6 +2937,10 @@ packages:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
     dependencies:
       '@types/mdast': 4.0.2
+    dev: false
+
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: false
 
   /merge-stream@2.0.0:
@@ -3171,6 +3294,13 @@ packages:
       '@types/nlcst': 1.0.0
     dev: false
 
+  /no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.5.2
+    dev: false
+
   /node-abi@3.51.0:
     resolution: {integrity: sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==}
     engines: {node: '>=10'}
@@ -3349,6 +3479,13 @@ packages:
       entities: 4.5.0
     dev: false
 
+  /pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.5.2
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3377,6 +3514,14 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
     dev: true
+
+  /periscopic@3.1.0:
+    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 3.0.3
+      is-reference: 3.0.2
+    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -4101,6 +4246,57 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
+  /svelte-chartjs@3.1.5(chart.js@4.4.1)(svelte@4.2.10):
+    resolution: {integrity: sha512-ka2zh7v5FiwfAX1oMflZ0HkNkgjHjFqANgRyC+vNYXfxtx2ku68Zo+2KgbKeBH2nS1ThDqkIACPzGxy4T0UaoA==}
+    peerDependencies:
+      chart.js: ^3.5.0 || ^4.0.0
+      svelte: ^4.0.0
+    dependencies:
+      chart.js: 4.4.1
+      svelte: 4.2.10
+    dev: false
+
+  /svelte-hmr@0.15.3(svelte@4.2.10):
+    resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
+    engines: {node: ^12.20 || ^14.13.1 || >= 16}
+    peerDependencies:
+      svelte: ^3.19.0 || ^4.0.0
+    dependencies:
+      svelte: 4.2.10
+    dev: false
+
+  /svelte2tsx@0.6.27(svelte@4.2.10)(typescript@5.3.3):
+    resolution: {integrity: sha512-E1uPW1o6VsbRz+nUk3fznZ2lSmCITAJoNu8AYefWSvIwE2pSB01i5sId4RMbWNzfcwCQl1DcgGShCPcldl4rvg==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      typescript: ^4.9.4 || ^5.0.0
+    dependencies:
+      dedent-js: 1.0.1
+      pascal-case: 3.1.2
+      svelte: 4.2.10
+      typescript: 5.3.3
+    dev: false
+
+  /svelte@4.2.10:
+    resolution: {integrity: sha512-Ep06yCaCdgG1Mafb/Rx8sJ1QS3RW2I2BxGp2Ui9LBHSZ2/tO/aGLc5WqPjgiAP6KAnLJGaIr/zzwQlOo1b8MxA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+      '@types/estree': 1.0.5
+      acorn: 8.11.2
+      aria-query: 5.3.0
+      axobject-query: 4.0.0
+      code-red: 1.0.4
+      css-tree: 2.3.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.2
+      locate-character: 3.0.0
+      magic-string: 0.30.5
+      periscopic: 3.1.0
+    dev: false
+
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -4248,7 +4444,6 @@ packages:
 
   /tslib@2.5.2:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}
-    dev: true
 
   /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/src/components/Articles.astro
+++ b/src/components/Articles.astro
@@ -1,5 +1,5 @@
 ---
-import Article, { ArticleProps } from "./Article.astro";
+import Article, { type ArticleProps } from "./Article.astro";
 import dayjs from "dayjs";
 
 type Props = {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ const { slug } = Astro.props;
   <nav>
     <HeaderLink slug={slug} href="/">トップページ</HeaderLink>
     <HeaderLink slug={slug} href="/archives/">アーカイブ</HeaderLink>
+    <HeaderLink slug={slug} href="/ranking/">ランキング</HeaderLink>
   </nav>
 </div>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,6 +27,6 @@ const { slug } = Astro.props;
     @apply text-4xl py-3 text-center;
   }
   nav {
-    @apply flex justify-center pb-2;
+    @apply flex justify-center pb-2 flex-col text-center md:flex-row;
   }
 </style>

--- a/src/components/RankChart.svelte
+++ b/src/components/RankChart.svelte
@@ -2,13 +2,8 @@
   import { Bar } from "svelte-chartjs";
   import { Chart as ChartJS } from "chart.js";
   import "chart.js/auto";
-  import type { ChartOptions } from "chart.js/auto";
+  import type { ChartData, ChartOptions } from "chart.js/auto";
 
-  // export let userRankings: {
-  //   user: string;
-  //   articleCount: number;
-  //   rank: number;
-  // }[];
   export let articles: {
     title: string;
     date: string;
@@ -54,8 +49,8 @@
       rank += users.length;
     });
 
-  // const rank_10_count = userRankings[10].articleCount;
   const ranking = userRankings.filter(({ rank }) => rank <= 10);
+  // const ranking = userRankings;
 
   const longestUsername = Math.max(...ranking.map(({ user }) => user.length));
   const rankingTick = ranking.map(({ user, rank }) => {
@@ -64,13 +59,29 @@
     return `${rank}. ${user}${padding}`;
   });
 
-  const data = {
+  const data: ChartData<"bar"> = {
     labels: rankingTick,
     datasets: [
       {
         label: "記事数",
         data: ranking.map(({ articleCount }) => articleCount),
         barThickness: 12,
+        backgroundColor: (ctx) => {
+          const rank = ranking[ctx.dataIndex].rank;
+          switch (rank) {
+            case 1:
+              return "#FFD700";
+            case 2:
+              return "#C0C0C0";
+            case 3:
+              return "#C47222";
+            default:
+              return "#6cb26a";
+          }
+        },
+        borderRadius: 5,
+        borderWidth: 0,
+        barPercentage: 0.5,
       },
     ],
   };
@@ -85,6 +96,7 @@
       },
     },
     responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: {
         display: false,
@@ -111,7 +123,7 @@
   };
 </script>
 
-<div id="rankings-container">
+<div id="rankings-container" class="w-[90vw] max-w-3xl px-1">
   <div>
     <Bar {data} {options} height={600} />
   </div>

--- a/src/components/RankChart.svelte
+++ b/src/components/RankChart.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { Bar } from "svelte-chartjs";
+  import { Chart as ChartJS } from "chart.js";
+  import "chart.js/auto";
+  import type { ChartOptions } from "chart.js/auto";
+
+  // export let userRankings: {
+  //   user: string;
+  //   articleCount: number;
+  //   rank: number;
+  // }[];
+  export let articles: {
+    title: string;
+    date: string;
+    runner: string;
+    url: string | null;
+    githubUser: string;
+    issueNumber: number;
+  }[];
+
+  // GitHubユーザーごとの記事数をカウント
+  const userCounts: { [user: string]: number } = {};
+  articles.forEach((article) => {
+    const user = article.githubUser;
+    if (userCounts[user]) {
+      userCounts[user]++;
+    } else {
+      userCounts[user] = 1;
+    }
+  });
+
+  // 同率のユーザーをグループ化
+  const groupedUsers: { [count: number]: { rank: number; users: string[] } } =
+    {};
+  Object.entries(userCounts).forEach(([user, count]) => {
+    if (!groupedUsers[count]) {
+      groupedUsers[count] = { rank: 0, users: [] };
+    }
+    groupedUsers[count].users.push(user);
+  });
+
+  // ランキングを計算し、1つの配列にまとめる
+  const userRankings: { user: string; articleCount: number; rank: number }[] =
+    [];
+  let rank = 1;
+  Object.keys(groupedUsers)
+    .map(Number)
+    .sort((a, b) => b - a)
+    .forEach((count) => {
+      const users = groupedUsers[count].users;
+      users.forEach((user) => {
+        userRankings.push({ user, articleCount: count, rank });
+      });
+      rank += users.length;
+    });
+
+  // const rank_10_count = userRankings[10].articleCount;
+  const ranking = userRankings.filter(({ rank }) => rank <= 10);
+
+  const longestUsername = Math.max(...ranking.map(({ user }) => user.length));
+  const rankingTick = ranking.map(({ user, rank }) => {
+    // FIXME: 左揃えにする方法がわからなかった
+    const padding = " ".repeat(longestUsername - user.length);
+    return `${rank}. ${user}${padding}`;
+  });
+
+  const data = {
+    labels: rankingTick,
+    datasets: [
+      {
+        label: "記事数",
+        data: ranking.map(({ articleCount }) => articleCount),
+        barThickness: 12,
+      },
+    ],
+  };
+
+  const options: ChartOptions<"bar"> = {
+    indexAxis: "y",
+    // Elements options apply to all of the options unless overridden in a dataset
+    // In this case, we are setting the border of each horizontal bar to be 2px wide
+    elements: {
+      bar: {
+        borderWidth: 2,
+      },
+    },
+    responsive: true,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      title: {
+        display: false,
+      },
+    },
+    scales: {
+      y: {
+        ticks: {
+          autoSkip: false,
+          padding: 4,
+          font: {
+            size: 16,
+            family: "monospace",
+          },
+        },
+        grid: {
+          display: false,
+        },
+      },
+    },
+  };
+</script>
+
+<div id="rankings-container">
+  <div>
+    <Bar {data} {options} height={600} />
+  </div>
+</div>

--- a/src/components/SeasonList.astro
+++ b/src/components/SeasonList.astro
@@ -95,9 +95,9 @@ export function sectionToSlug(section: Section): string {
   return `${section.fiscalYear}${seasonName}`;
 }
 
-type Props = { selected?: Section };
+type Props = { selected?: Section, linkDest: string };
 
-const { selected } = Astro.props;
+const { selected, linkDest } = Astro.props;
 const sections = getSectionArray();
 ---
 
@@ -110,7 +110,7 @@ const sections = getSectionArray();
           {displaySectionName(section)}
         </div>
       ) : (
-        <a href={`/ekiden/archives/${sectionToSlug(section)}`}>
+        <a href={`/ekiden/${linkDest}/${sectionToSlug(section)}`}>
           <div class="p-4 bg-gray-200 text-center hover:bg-[#97c795] rounded-md">
             {displaySectionName(section)}
           </div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -41,7 +41,7 @@ const ogImage = `${baseURL}/og-image.png`;
   <body>
     <main>
       <Header slug={slug} />
-      <div class="max-w-4xl flex-1 px-4 min-w-4xl">
+      <div class="max-w-4xl flex-1 px-4">
         <slot />
       </div>
       <Footer />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -41,7 +41,7 @@ const ogImage = `${baseURL}/og-image.png`;
   <body>
     <main>
       <Header slug={slug} />
-      <div class="max-w-4xl flex-1 px-4">
+      <div class="max-w-4xl flex-1 px-4 min-w-4xl">
         <slot />
       </div>
       <Footer />

--- a/src/pages/archives.astro
+++ b/src/pages/archives.astro
@@ -2,7 +2,7 @@
 import dayjs from "dayjs";
 import content from "../content.json";
 import Base from "../layouts/Base.astro";
-import ArchiveSections from "../components/ArchiveSections.astro";
+import SeasonList from "../components/SeasonList.astro";
 
 const articles = content.articles
   .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
@@ -18,7 +18,7 @@ const articles = content.articles
 ---
 
 <Base title="Vim 駅伝 - アーカイブ" slug="/archives/">
-  <ArchiveSections />
+  <SeasonList linkDest="archives" />
   {
     articles.map((article) => (
       <div

--- a/src/pages/archives/[section].astro
+++ b/src/pages/archives/[section].astro
@@ -48,7 +48,7 @@ const articles = content.articles
 
 <Base
   title={`Vim 駅伝 - アーカイブ - ${displaySectionName(section)}`}
-  slug={`/archives/${section}`}
+  slug={`/archives/${sectionToSlug(section)}`}
 >
   <SeasonList selected={section} linkDest="archives" />
   {

--- a/src/pages/archives/[section].astro
+++ b/src/pages/archives/[section].astro
@@ -1,13 +1,13 @@
 ---
 import dayjs from "dayjs";
 import content from "../../content.json";
-import ArchiveSections, {
+import SeasonList, {
   dateToSection,
   displaySectionName,
   getSectionArray,
   sectionToSlug,
   type Section,
-} from "../../components/ArchiveSections.astro";
+} from "../../components/SeasonList.astro";
 import Base from "../../layouts/Base.astro";
 
 export function getStaticPaths() {
@@ -48,9 +48,9 @@ const articles = content.articles
 
 <Base
   title={`Vim 駅伝 - アーカイブ - ${displaySectionName(section)}`}
-  slug="/archives/"
+  slug={`/archives/${section}`}
 >
-  <ArchiveSections selected={section} />
+  <SeasonList selected={section} linkDest="archives" />
   {
     articles.map((article) => (
       <div

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -1,0 +1,32 @@
+---
+import dayjs from "dayjs";
+import content from "../content.json";
+import Base from "../layouts/Base.astro";
+import ArchiveSections from "../components/ArchiveSections.astro";
+import RankChart from "../components/RankChart.svelte"
+
+const articles = content.articles
+  .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
+  .map((article, index) => ({
+    index: index + 1,
+    published: dayjs(article.date) <= dayjs() && article.url !== null,
+    shortDate: dayjs(article.date).format("M/D"),
+    runnerPath: article.githubUser
+      ? `/ekiden/runners/${article.githubUser}`
+      : undefined,
+    ...article,
+  })) .filter(({published}) => published) ;
+
+---
+
+<Base title="Vim 駅伝 - ランキング" slug="/ranking/">
+  <!-- <ArchiveSections /> -->
+  <RankChart articles={articles} client:only="svelte" ></RankChart>
+</Base>
+
+<style>
+  h1 {
+    @apply text-4xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+</style>

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -2,7 +2,7 @@
 import dayjs from "dayjs";
 import content from "../content.json";
 import Base from "../layouts/Base.astro";
-import ArchiveSections from "../components/ArchiveSections.astro";
+import SeasonList from "../components/SeasonList.astro";
 import RankChart from "../components/RankChart.svelte"
 
 const articles = content.articles
@@ -20,13 +20,27 @@ const articles = content.articles
 ---
 
 <Base title="Vim 駅伝 - ランキング" slug="/ranking/">
-  <!-- <ArchiveSections /> -->
-  <RankChart articles={articles} client:only="svelte" ></RankChart>
+  <SeasonList linkDest="ranking" />
+
+  <section class="py-4">
+    <h2>記事投稿数ランキング（総合）</h2>
+    <RankChart articles={articles} client:only="svelte" ></RankChart>
+  </section>
+
 </Base>
 
 <style>
   h1 {
     @apply text-4xl font-bold mt-4 mb-2;
     font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+
+  h2 {
+    @apply text-2xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+
+  section {
+    color: #666;
   }
 </style>

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -1,0 +1,75 @@
+---
+import dayjs from "dayjs";
+import content from "../../content.json";
+import SeasonList, {
+  dateToSection,
+  displaySectionName,
+  getSectionArray,
+  sectionToSlug,
+  type Section,
+} from "../../components/SeasonList.astro";
+import Base from "../../layouts/Base.astro";
+import RankChart from "../../components/RankChart.svelte";
+
+export function getStaticPaths() {
+  return getSectionArray().map((section) => ({
+    params: {
+      section: sectionToSlug(section),
+    },
+    props: {
+      section,
+    },
+  }));
+}
+
+type Props = {
+  section: Section;
+};
+const { section } = Astro.props;
+
+const articles = content.articles
+  .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
+  .map((article, index) => ({
+    index: index + 1,
+    published: dayjs(article.date) <= dayjs() && article.url !== null,
+    shortDate: dayjs(article.date).format("M/D"),
+    runnerPath: article.githubUser
+      ? `/ekiden/runners/${article.githubUser}`
+      : undefined,
+    ...article,
+  }))
+  .filter((article) => {
+    const articleSection = dateToSection(dayjs(article.date));
+    return (
+      articleSection.fiscalYear == section.fiscalYear &&
+      articleSection.season == section.season
+    );
+  });
+---
+
+<Base
+  title={`Vim 駅伝 - ランキング - ${displaySectionName(section)}`}
+  slug={`/ranking/${section}`}
+>
+  <SeasonList selected={section} linkDest="ranking" />
+  <section class="py-4">
+    <h2>記事投稿数ランキング（{displaySectionName(section)}）</h2>
+    <RankChart articles={articles} client:only="svelte" ></RankChart>
+  </section>
+</Base>
+
+<style>
+  h1 {
+    @apply text-4xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+
+  h2 {
+    @apply text-2xl font-bold mt-4 mb-2;
+    font-family: "Kaushan Script", "Yuji Syuku", serif;
+  }
+
+  section {
+    color: #666;
+  }
+</style>

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -49,7 +49,7 @@ const articles = content.articles
 
 <Base
   title={`Vim 駅伝 - ランキング - ${displaySectionName(section)}`}
-  slug={`/ranking/${section}`}
+  slug={`/ranking/${sectionToSlug(section)}`}
 >
   <SeasonList selected={section} linkDest="ranking" />
   <section class="py-4">


### PR DESCRIPTION
ランキングページを追加しました。

- グラフ描画のため chart.js を、グラフのコンポーネントを追加するため Svelte を導入しました。
- ひとまず10位の人まで表示する仕様となっています。
- アーカイブページ同様、季ごとのランキングも表示できるようにしました。
- 本当はグラフをクリックするとその人の記事一覧に飛ぶ、みたいなのがやりたかったんですが、実現する簡単な方法が調べた限り無さそうだったので一旦諦めてます。

<img width="879" alt="image" src="https://github.com/vim-jp/ekiden/assets/48883418/75b04f61-7778-4ff3-bb0a-1f311b7fd2ed">

@staticWagomU アドバイスありがとうございます！