### PR TITLE
fix: グラフの目盛りを1に変更& published なものだけ載るよう修正

### DIFF
--- a/src/components/RankChart.svelte
+++ b/src/components/RankChart.svelte
@@ -106,6 +106,11 @@
       },
     },
     scales: {
+      x: {
+        ticks: {
+          stepSize: 1,
+        },
+      },
       y: {
         ticks: {
           autoSkip: false,

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -42,7 +42,7 @@ const articles = content.articles
     const articleSection = dateToSection(dayjs(article.date));
     return (
       articleSection.fiscalYear == section.fiscalYear &&
-      articleSection.season == section.season
+      articleSection.season == section.season && article.published
     );
   });
 ---


### PR DESCRIPTION
表題のとおりです。

- グラフの横軸の目盛りを1にすることで "1.5" みたいな表示が出るのを防いでいます。
    - 将来的には総合ランキングの目盛りが細かくなりすぎるかもしれませんが、それはそうなった時に考えます。
- published なものだけがランキングに計上されるように修正しました。
    - もともと総合ランキングはそうなっていたのですが、季ごとのほうがそうなってませんでした。

![image](https://github.com/vim-jp/ekiden/assets/48883418/af873757-e3f0-4e5d-a0a1-1b4af302f47f)
