### PR TITLE
レイアウトの修正

### DIFF
--- a/src/components/SeasonList.astro
+++ b/src/components/SeasonList.astro
@@ -9,11 +9,18 @@ export type Section = {
   season: Season;
 };
 
-export function getSectionArray() {
+export function getSectionArray(showUnpublishedSeason: boolean) {
+
+  let articles = content.articles;
+  if (!showUnpublishedSeason) {
+    articles = articles
+      .filter((article) => dayjs(article.date) <= dayjs() && article.url !== null)
+  }
+
   const oldestSection: Section = { fiscalYear: 2023, season: 0 };
 
   const newestSection = dateToSection(
-    content.articles
+    articles
       .map((article) => dayjs(article.date))
       .reduce((max, date) => (date.isAfter(max) ? date : max)),
   );
@@ -95,10 +102,10 @@ export function sectionToSlug(section: Section): string {
   return `${section.fiscalYear}${seasonName}`;
 }
 
-type Props = { selected?: Section; linkDest: string };
+type Props = { selected?: Section; linkDest: string, showUnpublishedSeason?: boolean };
 
-const { selected, linkDest } = Astro.props;
-const sections = getSectionArray();
+const { selected, linkDest, showUnpublishedSeason } = Astro.props;
+const sections = getSectionArray(showUnpublishedSeason ?? true);
 ---
 
 <div class="grid grid-cols-4 gap-4 my-6">

--- a/src/components/SeasonList.astro
+++ b/src/components/SeasonList.astro
@@ -10,11 +10,11 @@ export type Section = {
 };
 
 export function getSectionArray(showUnpublishedSeason: boolean) {
-
   let articles = content.articles;
   if (!showUnpublishedSeason) {
-    articles = articles
-      .filter((article) => dayjs(article.date) <= dayjs() && article.url !== null)
+    articles = articles.filter(
+      (article) => dayjs(article.date) <= dayjs() && article.url !== null,
+    );
   }
 
   const oldestSection: Section = { fiscalYear: 2023, season: 0 };
@@ -102,7 +102,11 @@ export function sectionToSlug(section: Section): string {
   return `${section.fiscalYear}${seasonName}`;
 }
 
-type Props = { selected?: Section; linkDest: string, showUnpublishedSeason?: boolean };
+type Props = {
+  selected?: Section;
+  linkDest: string;
+  showUnpublishedSeason?: boolean;
+};
 
 const { selected, linkDest, showUnpublishedSeason } = Astro.props;
 const sections = getSectionArray(showUnpublishedSeason ?? true);

--- a/src/pages/archives/[section].astro
+++ b/src/pages/archives/[section].astro
@@ -11,7 +11,7 @@ import SeasonList, {
 import Base from "../../layouts/Base.astro";
 
 export function getStaticPaths() {
-  return getSectionArray().map((section) => ({
+  return getSectionArray(true).map((section) => ({
     params: {
       section: sectionToSlug(section),
     },
@@ -48,7 +48,7 @@ const articles = content.articles
 
 <Base
   title={`Vim 駅伝 - アーカイブ - ${displaySectionName(section)}`}
-  slug={`/archives/${sectionToSlug(section)}`}
+  slug={`/archives/`}
 >
   <SeasonList selected={section} linkDest="archives" />
   {

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -20,7 +20,7 @@ const articles = content.articles
 ---
 
 <Base title="Vim 駅伝 - ランキング" slug="/ranking/">
-  <SeasonList linkDest="ranking" />
+  <SeasonList linkDest="ranking" showUnpublishedSeason={false} />
 
   <section class="py-4">
     <h2>記事投稿数ランキング（総合）</h2>

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -52,7 +52,11 @@ const articles = content.articles
   title={`Vim 駅伝 - ランキング - ${displaySectionName(section)}`}
   slug={`/ranking/`}
 >
-  <SeasonList selected={section} linkDest="ranking" showUnpublishedSeason={false} />
+  <SeasonList
+    selected={section}
+    linkDest="ranking"
+    showUnpublishedSeason={false}
+  />
   <section class="py-4">
     <h2>記事投稿数ランキング（{displaySectionName(section)}）</h2>
     <RankChart articles={articles} client:only="svelte" />

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -12,7 +12,7 @@ import Base from "../../layouts/Base.astro";
 import RankChart from "../../components/RankChart.svelte";
 
 export function getStaticPaths() {
-  return getSectionArray().map((section) => ({
+  return getSectionArray(false).map((section) => ({
     params: {
       section: sectionToSlug(section),
     },
@@ -50,9 +50,9 @@ const articles = content.articles
 
 <Base
   title={`Vim 駅伝 - ランキング - ${displaySectionName(section)}`}
-  slug={`/ranking/${sectionToSlug(section)}`}
+  slug={`/ranking/`}
 >
-  <SeasonList selected={section} linkDest="ranking" />
+  <SeasonList selected={section} linkDest="ranking" showUnpublishedSeason={false} />
   <section class="py-4">
     <h2>記事投稿数ランキング（{displaySectionName(section)}）</h2>
     <RankChart articles={articles} client:only="svelte" />

--- a/src/pages/runners/[runner].astro
+++ b/src/pages/runners/[runner].astro
@@ -21,7 +21,7 @@ const runnersArticles = newArticles
   .filter((article) => article.githubUser === runner)
   .sort((a, b) => dayjs(a.date).unix() - dayjs(b.date).unix())
   .map((article, index) => ({
-    index: index + 1,
+    index: index,
     published: dayjs(article.date) <= dayjs() && article.url !== null,
     shortDate: dayjs(article.date).format("M/D"),
     year: dayjs(article.date).format("YYYY"),
@@ -36,7 +36,7 @@ const runnersArticles = newArticles
       <>
         <h2
           class={
-            article.index === 1 ||
+            article.index === 0 ||
             article.year !== runnersArticles[article.index - 1].year
               ? "text-2xl font-bold mt-8 mb-4"
               : "hidden"


### PR DESCRIPTION
3点修正を行いました。

- ランキングページでまだ記事のない季が表示される不具合の修正
    - アーカイブページでは未公開の記事も表示するようにしていますが、
        そのロジックを使いまわしたことでまだ記事のない季（現在だと 2024年春季）のランキングページも表示されるようになっていました。
        これを修正し、ランキングページについてはまだ記事のない季が選べないようにしました。
        - アーカイブページは元のまま、unpublished な季も表示されるようにしています。

    ![image](https://github.com/vim-jp/ekiden/assets/48883418/3dfe4c16-67fd-4b06-9957-958ce3254ee9)

- 季ごとのアーカイブページ・ランキングページで、ヘッダーに下線が表示されない仕様の修正
    - 今まで、季ごとのアーカイブページではヘッダーの「アーカイブ」に下線が表示されませんでした。
        - これは仕様で、季ごとのアーカイブページからも総合アーカイブページに飛べるようにするためでした。
        - 「総合」ボタンの追加により上記の仕様が不要になったため、季ごとのページでも下線が表示されるようにしました。
        - ランキングページも同様。

    ![image](https://github.com/vim-jp/ekiden/assets/48883418/835f9d11-9ba0-405b-bf81-5fc2230cd665)

- 著者ごとの記事一覧で、2023年から記事を書いている人は「2024 年」 header が表示されない不具合を修正
    - これはおそらく単なる indexing のバグだったので修正しました。

    ![image](https://github.com/vim-jp/ekiden/assets/48883418/1ab47fca-0ba0-4ab7-9b75-adcf27872e06)
