### PR TITLE
メインの要素の width が子要素に依存している

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -48,7 +48,7 @@ const ogImage = `${baseURL}/og-image.png`;
       class="flex justify-center items-center flex-col p-0 m-0 min-h-screen"
     >
       <Header slug={slug} />
-      <div class="max-w-4xl flex-1 px-4">
+      <div class="max-w-4xl flex-1 px-4 w-full">
         <slot />
       </div>
       <Footer />


### PR DESCRIPTION
駅伝記事のタイトルの長さに依って親要素の width が変化しています。
(添付画像を参照)
問題となっている要素の width を 100% に指定することで解決します。

短い場合：
![20240302-150236-048358369](https://github.com/vim-jp/ekiden/assets/104410688/147e754e-af00-4a64-a3bf-91ed00ce12eb)

長い場合：
![20240302-150323-693117554](https://github.com/vim-jp/ekiden/assets/104410688/3cb3be78-7c1f-4fbe-8cdb-a5d5cc2d26dc)

理想の挙動：
![20240302-150406-385305905](https://github.com/vim-jp/ekiden/assets/104410688/b96643a8-6942-4da8-9642-a7ba09b104d4)