### PR TITLE
change type of `year` in article: string to number

### DIFF
--- a/src/lib/article.ts
+++ b/src/lib/article.ts
@@ -32,7 +32,7 @@ export function getArticles(options: ReturnArticlesFilterOptions = {}) {
          */
         published: dayjs(article.date) <= today && article.url != null,
         shortDate: dayjs(article.date).format("M/D"),
-        year: dayjs(article.date).format("YYYY"),
+        year: dayjs(article.date).year(),
         /** index は記事のインデックス番号。０から始まる */
         originalIndex: index,
         runnerPath: article.githubUser

--- a/src/pages/runners/[runner].astro
+++ b/src/pages/runners/[runner].astro
@@ -28,7 +28,7 @@ const runnersArticles = getArticles({ runner });
       <>
         <h2
           class={
-            index === 0 || article.year !== articles.at(index - 1)?.year
+            index === 0 || article.year > articles.at(index - 1)?.year
               ? "text-2xl font-bold mt-8 mb-4"
               : "hidden"
           }


### PR DESCRIPTION
`articles[0].year`の値をstringから数字に変更する
取り回しがしやすくなるはず

runnerのページで
表示に相違がないことを確認


<img width="398" alt="Screenshot 2024-03-05 at 01 08 35" src="https://github.com/vim-jp/ekiden/assets/1560508/e860d92e-cd00-45fd-9208-e8a1e6f2b94a">
