### PR TITLE
[Update] Update Archive page design.

### DIFF
--- a/src/components/ArticleInArchive.astro
+++ b/src/components/ArticleInArchive.astro
@@ -1,6 +1,7 @@
 ---
 import type { ProcessedArticle } from "@/lib/article.js";
 import type { SetOptional } from "type-fest";
+import RunnerImage from "/public/1f3c3.svg";
 
 type Props = SetOptional<ProcessedArticle, "runner">;
 
@@ -8,37 +9,44 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
   Astro.props;
 ---
 
-<div class={published ? "w-full hover:bg-[#efefef] hover:shadow-md" : "w-full"}>
-  <a href={published ? url : undefined}>
-    <div class="p-4">
-      <div class="flex items-center">
-        <div
-          class={published
-            ? "rounded-full flex-shrink-0 w-16 h-16 flex items-center justify-center mr-4 bg-[#477745] text-white"
-            : "rounded-full flex-shrink-0 w-16 h-16 flex items-center justify-center mr-4 text-[#477745] border border-[#477745]"}
-        >
-          <div class="text-center">
-            {
-              originalIndex !== undefined && (
-                <div class="text-lg font-bold">#{originalIndex + 1}</div>
-              )
-            }
-            <div class="text-sm">{shortDate}</div>
+<div>
+  <div
+    class={published ? "w-full hover:bg-[#efefef] hover:shadow-md" : "w-full"}
+  >
+    <a href={published ? url : undefined}>
+      <div class="pl-2 pr-2 pt-2">
+        <div class="flex items-center">
+          <div
+            class={published
+              ? "rounded-full flex-shrink-0 w-16 h-16 flex items-center justify-center mr-4 bg-[#477745] text-white"
+              : "rounded-full flex-shrink-0 w-16 h-16 flex items-center justify-center mr-4 text-[#477745] border border-[#477745]"}
+          >
+            <div class="text-center">
+              {
+                originalIndex !== undefined && (
+                  <div class="text-lg font-bold">#{originalIndex + 1}</div>
+                )
+              }
+              <div class="text-sm">{shortDate}</div>
+            </div>
+          </div>
+          <div class={published ? "text-gray-700" : "text-gray-500"}>
+            <h3 class="text-md mb-1 font-bold md:text-lg">
+              {title}
+            </h3>
           </div>
         </div>
-        <div class={published ? "text-gray-700" : "text-gray-500"}>
-          <h3 class="text-md mb-1 font-bold md:text-lg">
-            {title}
-          </h3>
-          {
-            runner !== undefined && runnerPath !== undefined && (
-              <a href={runnerPath} class="md:text-md text-sm">
-                {runner}
-              </a>
-            )
-          }
-        </div>
       </div>
-    </div>
-  </a>
+    </a>
+  </div>
+  {
+    runner !== undefined && runnerPath !== undefined && (
+      <div class="mb-4 w-full text-right">
+        <a href={runnerPath} class="md:text-md inline-block text-sm">
+          <img src={RunnerImage.src} class="inline w-4 [--i:1]" />
+          &nbsp;<span class="underline">{runner}</span>
+        </a>
+      </div>
+    )
+  }
 </div>

--- a/src/components/ArticleInArchive.astro
+++ b/src/components/ArticleInArchive.astro
@@ -9,12 +9,12 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
   Astro.props;
 ---
 
-<div>
+<div class="mb-4 border-b pb-2">
   <div
     class={published ? "w-full hover:bg-[#efefef] hover:shadow-md" : "w-full"}
   >
     <a href={published ? url : undefined}>
-      <div class="pl-2 pr-2 pt-2">
+      <div class="p-2">
         <div class="flex items-center">
           <div
             class={published
@@ -41,7 +41,7 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
   </div>
   {
     runner !== undefined && runnerPath !== undefined && (
-      <div class="mb-4 w-full text-right">
+      <div class="w-full text-right">
         <a href={runnerPath} class="md:text-md inline-block text-sm">
           <img src={RunnerImage.src} class="inline w-4 [--i:1]" />
           &nbsp;<span class="underline">{runner}</span>


### PR DESCRIPTION
1. Duplicate a link divided.
2. Runner's link moved left to right.
3. Add runner icon.

Issuesの#338対応。
重複しているAタグの対応。
筆者名を左端から右端に移動し、ついでにランナーアイコンをつけてみました。

PC版スクリーンショット
![pc](https://github.com/vim-jp/ekiden/assets/40669/4887ef9a-7f46-426d-9a9a-0aac370a9306)

SP版スクリーンショット
![sp](https://github.com/vim-jp/ekiden/assets/40669/26fbff66-b9d6-4d2a-a980-8066f02e4c82)
