### PR TITLE
「統計」のページを追加

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,5 +14,6 @@ const { slug } = Astro.props;
     <HeaderLink slug={slug} href="/">トップページ</HeaderLink>
     <HeaderLink slug={slug} href="/archives/">アーカイブ</HeaderLink>
     <HeaderLink slug={slug} href="/ranking/">ランキング</HeaderLink>
+    <HeaderLink slug={slug} href="/statistics/">統計</HeaderLink>
   </nav>
 </div>

--- a/src/components/RecordCard.astro
+++ b/src/components/RecordCard.astro
@@ -1,16 +1,21 @@
 ---
 export type RecordType = {
   title: string;
-  records: (number | string)[];
+  records: number[] | string[];
   unit: string;
-  noDegitHighlight?: boolean;
+  /**
+   * 桁ごとの下線の強調が有効になる
+   * 文字列の表示の場合は無効にする
+   * @default true
+   */
+  enabledDigitHighlight?: boolean;
 };
 
 type Props = RecordType;
-const { title, records, unit, noDegitHighlight } = Astro.props;
+const { title, records, unit, enabledDigitHighlight = true } = Astro.props;
 ---
 
-<div class="flex w-full flex-col gap-3 sm:flex-row">
+<div class="flex w-full flex-col gap-2 sm:flex-row">
   <div class="flex flex-1 justify-center self-center sm:self-start">
     <div
       class="inline-box w-56 justify-self-center rounded bg-ekiden-green-500 px-3 py-2 text-center font-ekiden-heading text-3xl text-ekiden-white-500"
@@ -24,26 +29,26 @@ const { title, records, unit, noDegitHighlight } = Astro.props;
     {
       records.map((record) => {
         return (
-          <div class="flex">
+          <div class="flex gap-2">
             <div>
-              {noDegitHighlight ? (
-                <span class="border-b-2 border-b-gray-500 font-ekiden-mono text-4xl font-thin">
-                  {record}
-                </span>
-              ) : (
+              {enabledDigitHighlight ? (
                 <div class="flex items-center gap-2">
-                  {[...record.toString()].map((degit) => {
-                    return degit === "." ? (
+                  {[...record.toString()].map((digit) => {
+                    return digit === "." ? (
                       <span class="font-ekiden-mono text-4xl font-extrabold">
                         .
                       </span>
                     ) : (
                       <span class="border-b-2 border-b-gray-500 font-ekiden-mono text-4xl font-thin">
-                        {degit}
+                        {digit}
                       </span>
                     );
                   })}
                 </div>
+              ) : (
+                <span class="border-b-2 border-b-gray-500 font-ekiden-mono text-4xl font-thin">
+                  {record}
+                </span>
               )}
             </div>
             <div class="self-end font-ekiden-base text-xl">{unit}</div>

--- a/src/components/RecordCard.astro
+++ b/src/components/RecordCard.astro
@@ -1,0 +1,55 @@
+---
+export type RecordType = {
+  title: string;
+  records: (number | string)[];
+  unit: string;
+  noDegitHighlight?: boolean;
+};
+
+type Props = RecordType;
+const { title, records, unit, noDegitHighlight } = Astro.props;
+---
+
+<div class="flex w-full flex-col gap-3 sm:flex-row">
+  <div class="flex flex-1 justify-center self-center sm:self-start">
+    <div
+      class="inline-box w-56 justify-self-center rounded bg-ekiden-green-500 px-3 py-2 text-center font-ekiden-heading text-3xl text-ekiden-white-500"
+    >
+      {title}
+    </div>
+  </div>
+  <div
+    class="flex flex-1 flex-col items-center gap-2 self-center justify-self-start"
+  >
+    {
+      records.map((record) => {
+        return (
+          <div class="flex">
+            <div>
+              {noDegitHighlight ? (
+                <span class="border-b-2 border-b-gray-500 font-ekiden-mono text-4xl font-thin">
+                  {record}
+                </span>
+              ) : (
+                <div class="flex items-center gap-2">
+                  {[...record.toString()].map((degit) => {
+                    return degit === "." ? (
+                      <span class="font-ekiden-mono text-4xl font-extrabold">
+                        .
+                      </span>
+                    ) : (
+                      <span class="border-b-2 border-b-gray-500 font-ekiden-mono text-4xl font-thin">
+                        {degit}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            <div class="self-end font-ekiden-base text-xl">{unit}</div>
+          </div>
+        );
+      })
+    }
+  </div>
+</div>

--- a/src/lib/article.ts
+++ b/src/lib/article.ts
@@ -14,7 +14,7 @@ export type ReturnArticlesFilterOptions = {
 /**
  * 記事の一覧を返す
  * @param {ReturnArticlesOptions} options
- * @param {boolean} options.fileterByIsPublished
+ * @param {boolean} options.isPublished
  * @param {string} options.runner
  */
 export function getArticles(options: ReturnArticlesFilterOptions = {}) {

--- a/src/pages/statistics/index.astro
+++ b/src/pages/statistics/index.astro
@@ -1,0 +1,78 @@
+---
+import Base from "@/layouts/Base.astro";
+import { getArticles } from "@/lib/article";
+import RecordCard, { type RecordType } from "@/components/RecordCard.astro";
+import dayjs from "dayjs";
+
+const articles = getArticles();
+const publishedArticles = getArticles({ isPublished: true });
+const runnersWithDuplicate = articles.map((article) => article.githubUser);
+const runners = [...new Set(runnersWithDuplicate)];
+const runnersWithCount = runners.map((runner) => {
+  return {
+    name: runner,
+    count: runnersWithDuplicate.filter((r) => r === runner).length,
+  };
+});
+
+const records: RecordType[] = [
+  {
+    title: "総記事数",
+    records: [articles.length],
+    unit: "本",
+  },
+  {
+    title: "総公開記事数",
+    records: [publishedArticles.length],
+    unit: "本",
+  },
+  {
+    title: "総ランナー数",
+    records: [runners.length],
+    unit: "人",
+  },
+  {
+    title: "平均投稿数",
+    records: [Math.round((articles.length / runners.length) * 100) / 100],
+    unit: "本/人",
+  },
+  {
+    title: "最多投稿者",
+    records: [
+      ...runnersWithCount.filter(
+        (runner) =>
+          runner.count ===
+          Math.max(...runnersWithCount.map((runner) => runner.count)),
+      ),
+    ].map((runner) => runner.name),
+    unit: "さん",
+    noDegitHighlight: true,
+  },
+  {
+    title: "経過日数",
+    records: [
+      dayjs(publishedArticles.at(-1)?.date).diff(
+        dayjs(publishedArticles[0].date),
+        "day",
+      ),
+    ],
+    unit: "日",
+  },
+];
+---
+
+<Base slug="statistics" title="Vim駅伝 - 統計">
+  <h2 class="my-5 w-full text-center font-ekiden-heading text-4xl">統計</h2>
+  <div class="my-5 flex flex-col gap-3 pb-10">
+    {
+      records.map((record) => (
+        <RecordCard
+          title={record.title}
+          records={record.records}
+          unit={record.unit}
+          noDegitHighlight={record.noDegitHighlight}
+        />
+      ))
+    }
+  </div>
+</Base>

--- a/src/pages/statistics/index.astro
+++ b/src/pages/statistics/index.astro
@@ -8,12 +8,17 @@ const articles = getArticles();
 const publishedArticles = getArticles({ isPublished: true });
 const runnersWithDuplicate = articles.map((article) => article.githubUser);
 const runners = [...new Set(runnersWithDuplicate)];
+/** 走者ごとの記事数 */
 const runnersWithCount = runners.map((runner) => {
   return {
     name: runner,
     count: runnersWithDuplicate.filter((r) => r === runner).length,
   };
 });
+/** 一本以上記事を投稿した走者の数 */
+const runnersWithArticles = [
+  ...new Set(publishedArticles.map((article) => article.githubUser)),
+];
 
 const records: RecordType[] = [
   {
@@ -28,12 +33,14 @@ const records: RecordType[] = [
   },
   {
     title: "総ランナー数",
-    records: [runners.length],
+    records: [runnersWithArticles.length],
     unit: "人",
   },
   {
     title: "平均投稿数",
-    records: [Math.round((articles.length / runners.length) * 100) / 100],
+    records: [
+      Math.round((articles.length / runnersWithArticles.length) * 100) / 100,
+    ],
     unit: "本/人",
   },
   {
@@ -46,7 +53,7 @@ const records: RecordType[] = [
       ),
     ].map((runner) => runner.name),
     unit: "さん",
-    noDegitHighlight: true,
+    enabledDigitHighlight: false,
   },
   {
     title: "経過日数",
@@ -63,14 +70,14 @@ const records: RecordType[] = [
 
 <Base slug="statistics" title="Vim駅伝 - 統計">
   <h2 class="my-5 w-full text-center font-ekiden-heading text-4xl">統計</h2>
-  <div class="my-5 flex flex-col gap-3 pb-10">
+  <div class="my-5 flex flex-col gap-8 pb-10">
     {
       records.map((record) => (
         <RecordCard
           title={record.title}
           records={record.records}
           unit={record.unit}
-          noDegitHighlight={record.noDegitHighlight}
+          enabledDigitHighlight={record.enabledDigitHighlight}
         />
       ))
     }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -25,6 +25,7 @@ module.exports = {
     fontFamily: {
       "ekiden-heading": ["Kaushan Script", "Yuji Syuku", "serif"],
       "ekiden-base": ["sans-serif"],
+      "ekiden-mono": ["DejaVu Sans Mono", "monospace"]
     }
   },
   plugins: [],


### PR DESCRIPTION
## 「統計」のページを追加しました。

![Screenshot 2024-03-23 21 40 12](https://github.com/vim-jp/ekiden/assets/140703515/7a8edc42-63d1-4b0d-9ad8-cd9a5d5309d9)

「最多投稿者」の箇所は、複数の人の表示に対応しています。

#### その他の変更点
- `tailwind.config.cjs`にmonospaceのためのフォントの設定を追加
- `src/lib/articles.ts`のJSDocのコメントが間違っている問題を修正