### PR TITLE
Revert "Update content.json by #400"

### DIFF
--- a/src/content.json
+++ b/src/content.json
@@ -1489,14 +1489,6 @@
       "issueNumber": 391
     },
     {
-      "title": "何か",
-      "date": "2024-05-08",
-      "runner": "kyoh86",
-      "url": null,
-      "githubUser": "kyoh86",
-      "issueNumber": 400
-    },
-    {
       "title": "vimtutorの次（その2）",
       "date": "2024-05-13",
       "runner": "K Ikeda",


### PR DESCRIPTION
2024-05-08の割り当てを巡ってIssueの起票 (#400, #401) が重複してしまった。
会話の上で先に立てた #400 のCloseを実施したが、content.jsonの更新が起こっていないため、引き続き #401 が成立していない。
一度 #400 による contents.jsonの 変更をこのPull RequestでRevertし、再度 #401 の更新を行うことで正常化したい。

This reverts commit d9c6e8b854c03a2bc274320e19a2a31b0182105e.
