### PR TITLE
Specify to direct-only for npm upgrading by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: direct
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
c.f. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow