### PR TITLE
Fix section extracting with multiline

### DIFF
--- a/scripts/update-article.ts
+++ b/scripts/update-article.ts
@@ -59,7 +59,7 @@ function validatePublishDate(date: string) {
 }
 
 function unescapeContent(s: string): string {
-  return /^(`*)(.*)\1$/.exec(s)![2].trim();
+  return /^(`*)(.*)\1$/.exec(s)![2].trim().replaceAll(/[\r\n]/g, "");
 }
 
 function descriptionToArticle(

--- a/scripts/update-article.ts
+++ b/scripts/update-article.ts
@@ -77,7 +77,7 @@ function descriptionToArticle(
   };
 
   sections.forEach((section) => {
-    const matched = section.match(/([^\r\n]+)[\r\n]*(.*)/);
+    const matched = section.match(/([^\r\n]+)[\r\n]*(.*)/s);
     if (!matched) {
       throw new ValidationError(`不正な形式のセクションです。: ${section}`);
     }


### PR DESCRIPTION
Issues の description から JSON のエントリーを生成する際、description のセクションが複数行あった場合に最初の 1 行しか参照されない問題がありました。
大抵は 1 行しかないので問題になっていませんでしたが、一部の文字をエスケープするためにコードブロックなどを使おうとすると問題になりました。
この変更では複数行の対応をするとともに、content からは改行を消すようにしました。