### PR TITLE
Fix error handling in update-article

### DIFF
--- a/.github/workflows/update-article.yml
+++ b/.github/workflows/update-article.yml
@@ -35,7 +35,7 @@ jobs:
                --issueNumber '${{ github.event.issue.number }}' \
                --githubUser '${{ github.event.issue.user.login }}' \
                ${{ github.event.issue.state == 'closed' && github.event.issue.state_reason != 'completed' && 'delete' || '' }} \
-               2>> "${GITHUB_OUTPUT}"
+               2>> "${GITHUB_OUTPUT}" && true
           echo 'MESSAGE' >> "${GITHUB_OUTPUT}"
       - name: 'Push changes'
         id: 'push'


### PR DESCRIPTION
If the command fails, a step fails immediately.
In this case, `MESSAGE` does not output.
As a result, the job fails due to malformed output file.
To prevent this, change the command so that it always succeeds.