### PR TITLE
隣接兄弟要素を使う実装に修正

### DIFF
--- a/src/components/ArticleInArchive.astro
+++ b/src/components/ArticleInArchive.astro
@@ -9,7 +9,7 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
   Astro.props;
 ---
 
-<div class="mb-4 [&+div]:border-t pb-2">
+<div class="mb-4 pb-2 [&+div]:border-t">
   <div
     class={published ? "w-full hover:bg-[#efefef] hover:shadow-md" : "w-full"}
   >

--- a/src/components/ArticleInArchive.astro
+++ b/src/components/ArticleInArchive.astro
@@ -9,7 +9,7 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
   Astro.props;
 ---
 
-<div class="mb-4 border-b pb-2">
+<div class="mb-4 [&+div]:border-t pb-2">
   <div
     class={published ? "w-full hover:bg-[#efefef] hover:shadow-md" : "w-full"}
   >
@@ -43,7 +43,7 @@ const { title, url, originalIndex, runner, runnerPath, published, shortDate } =
     runner !== undefined && runnerPath !== undefined && (
       <div class="w-full text-right">
         <a href={runnerPath} class="md:text-md inline-block text-sm">
-          <img src={RunnerImage.src} class="inline w-6 [--i:1]" />
+          <img src={RunnerImage.src} class="inline w-6" />
           &nbsp;<span class="underline">{runner}</span>
         </a>
       </div>


### PR DESCRIPTION
afterのように最後の要素にはborderがつかないように修正

before 

![image](https://github.com/user-attachments/assets/56e1aa3a-07fa-4a3c-b160-7271f0d4d639)

after

![image](https://github.com/user-attachments/assets/232d614c-e0ea-424c-8afc-075a6ccbf3cd)

