### PR TITLE
feat: use corepack to manage pnpm version

### DIFF
--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -11,14 +11,13 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Setup pnpm
+        run: corepack enable
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 9.1.2
+          node-version-file: package.json
+          cache: pnpm
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Run tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,15 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+      - name: Setup pnpm
+        run: corepack enable
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: package.json
+          cache: pnpm
       - name: Install, build, and upload your site
         uses: withastro/action@v2
-        with:
-          package-manager: pnpm@9.1.2
         env:
           TZ: 'Asia/Tokyo'
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@
 参加方法はVim駅伝[初日の記事](https://thinca.hatenablog.com/entry/vim-ekiden-is-launched)をご覧ください。
 
 サイトの構成は [Astro](https://astro.build) を用いて行っています。
-ローカルでのビルド方法は Astro の公式ドキュメントに従ってください。
+
+ローカルでのビルドは:
+```sh
+git clone https://github.com/vim-jp/ekiden.git
+cd ekiden
+corepack enable
+pnpm install
+pnpm build
+```
+で行ってください。
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。
 ただし、各記事の内容やタイトルの権利は執筆者に帰属します。

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0",
-    "pnpm": ">=9.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "dev": "astro dev",
@@ -49,5 +48,6 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.1"
   },
-  "private": true
+  "private": true,
+  "packageManager": "pnpm@9.7.0+sha512.dc09430156b427f5ecfc79888899e1c39d2d690f004be70e05230b72cb173d96839587545d09429b55ac3c429c801b4dc3c0e002f653830a420fa2dd4e3cf9cf"
 }


### PR DESCRIPTION
corepackでpnpmのバージョンを管理するようにする。

手元で開発する時も
```sh
corepack enable pnpm
```
とすることで、指定されているpnpmのバージョンを使えるようになるので便利
参考: https://zenn.dev/monicle/articles/1c06f3f75b2cb1