### PR TITLE
fix(ci): lintとbuildをステップごとに分ける

### DIFF
--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -29,4 +29,3 @@ jobs:
         run: pnpm check
       - name: Run Build
         run: pnpm build
-

--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -21,9 +21,12 @@ jobs:
           version: 9.1.2
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
-      - name: Run tests
-        run: |
-          pnpm run lint:check
-          pnpm run prettier:check
-          pnpm run check
-          pnpm run build
+      - name: Run ESLint
+        run: pnpm lint:check
+      - name: Run Prettier
+        run: pnpm prettier:check
+      - name: Run Astro Check
+        run: pnpm check
+      - name: Run Build
+        run: pnpm build
+


### PR DESCRIPTION
エラーになった時にどれが悪いのか分かりづらいので