### PR TITLE
pnpmの機能でpnpmとnodeのバージョンを管理する

### DIFF
--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -17,8 +17,6 @@ jobs:
           node-version: 20
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 9.1.2
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Run tests

--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: 20
       - name: Install, build, and upload your site
         uses: withastro/action@v3
-        with:
-          package-manager: pnpm@9.1.2
         env:
           TZ: 'Asia/Tokyo'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+manage-package-manager-versions=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 manage-package-manager-versions=true
+use-node-version=20.17.0

--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
     "typescript-eslint": "^8.5.0",
     "ufo": "^1.5.4"
   },
-  "private": true
+  "private": true,
+  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
 }


### PR DESCRIPTION
pnpmの機能でnodeとpnpmのversionを管理することのメリットは以下の通り
- 公式で推奨されている
  - https://github.com/pnpm/pnpm/releases/tag/v9.7.0
  - https://pnpm.io/ja/npmrc#manage-package-manager-versions
- 各々のlocal環境でもpackage.jsonで指定されているpnpm/nodeのバージョンを使うように強制できる
- GitHub Actionsでも自動的に該当のversionのnodeが落ちてくる([参考](https://github.com/vim-jp/ekiden/actions/runs/10930812387/job/30344523385?pr=598#step:4:7))

ついでにpnpmのversionを9.10にし、nodeのバージョンも20.17.0にしました