### PR TITLE
build(deps): bump deno v1.46.1 to v2.0.0

### DIFF
--- a/.github/workflows/update-article.yml
+++ b/.github/workflows/update-article.yml
@@ -25,7 +25,7 @@ jobs:
           ssh-key: '${{ secrets.ARTICLE_DEPLOY_KEY }}'
       - uses: 'denoland/setup-deno@v2'
         with:
-          deno-version: 'v1.46.1'
+          deno-version: 'v2.0.0'
       - name: 'Run script'
         id: 'script'
         run: |


### PR DESCRIPTION
SSIA, setup-denoは #648 でv2対応済み