### PR TITLE
RankingページでSvelteのComponentが表示されない問題を修正 & Svelte5にアプデ

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "chart.js": "^4.4.7",
     "dayjs": "^1.11.13",
     "sharp": "^0.33.5",
-    "svelte": "^5.19.5",
-    "svelte-chartjs": "^3.1.5"
+    "svelte": "^5.19.5"
   },
   "devDependencies": {
     "@astrojs/ts-plugin": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/rss": "^4.0.11",
-    "@astrojs/svelte": "^5.7.3",
+    "@astrojs/svelte": "^7.0.4",
     "@fontsource/kaushan-script": "^5.1.1",
     "@fontsource/yuji-syuku": "^5.1.1",
     "@unocss/reset": "^65.4.3",
@@ -29,7 +29,7 @@
     "chart.js": "^4.4.7",
     "dayjs": "^1.11.13",
     "sharp": "^0.33.5",
-    "svelte": "^4.2.19",
+    "svelte": "^5.19.5",
     "svelte-chartjs": "^3.1.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       svelte:
         specifier: ^5.19.5
         version: 5.19.5
-      svelte-chartjs:
-        specifier: ^3.1.5
-        version: 3.1.5(chart.js@4.4.7)(svelte@5.19.5)
     devDependencies:
       '@astrojs/ts-plugin':
         specifier: ^1.10.4
@@ -2374,12 +2371,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  svelte-chartjs@3.1.5:
-    resolution: {integrity: sha512-ka2zh7v5FiwfAX1oMflZ0HkNkgjHjFqANgRyC+vNYXfxtx2ku68Zo+2KgbKeBH2nS1ThDqkIACPzGxy4T0UaoA==}
-    peerDependencies:
-      chart.js: ^3.5.0 || ^4.0.0
-      svelte: ^4.0.0
 
   svelte2tsx@0.7.34:
     resolution: {integrity: sha512-WTMhpNhFf8/h3SMtR5dkdSy2qfveomkhYei/QW9gSPccb0/b82tjHvLop6vT303ZkGswU/da1s6XvrLgthQPCw==}
@@ -5598,11 +5589,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  svelte-chartjs@3.1.5(chart.js@4.4.7)(svelte@5.19.5):
-    dependencies:
-      chart.js: 4.4.7
-      svelte: 5.19.5
 
   svelte2tsx@0.7.34(svelte@5.19.5)(typescript@5.7.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.0.11
         version: 4.0.11
       '@astrojs/svelte':
-        specifier: ^5.7.3
-        version: 5.7.3(astro@5.1.10(@types/node@22.10.10)(jiti@2.4.2)(rollup@4.27.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0))(svelte@4.2.19)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
+        specifier: ^7.0.4
+        version: 7.0.4(@types/node@22.10.10)(astro@5.1.10(@types/node@22.10.10)(jiti@2.4.2)(rollup@4.27.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0))(jiti@2.4.2)(svelte@5.19.5)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0)
       '@fontsource/kaushan-script':
         specifier: ^5.1.1
         version: 5.1.1
@@ -39,11 +39,11 @@ importers:
         specifier: ^0.33.5
         version: 0.33.5
       svelte:
-        specifier: ^4.2.19
-        version: 4.2.19
+        specifier: ^5.19.5
+        version: 5.19.5
       svelte-chartjs:
         specifier: ^3.1.5
-        version: 3.1.5(chart.js@4.4.7)(svelte@4.2.19)
+        version: 3.1.5(chart.js@4.4.7)(svelte@5.19.5)
     devDependencies:
       '@astrojs/ts-plugin':
         specifier: ^1.10.4
@@ -92,7 +92,7 @@ importers:
         version: 0.14.1
       prettier-plugin-svelte:
         specifier: ^3.3.3
-        version: 3.3.3(prettier@3.4.2)(svelte@4.2.19)
+        version: 3.3.3(prettier@3.4.2)(svelte@5.19.5)
       type-fest:
         specifier: ^4.33.0
         version: 4.33.0
@@ -110,10 +110,6 @@ importers:
         version: 65.4.3(postcss@8.4.49)(rollup@4.27.3)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))(vue@3.5.13(typescript@5.7.3))
 
 packages:
-
-  '@ampproject/remapping@2.2.1':
-    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
-    engines: {node: '>=6.0.0'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -162,12 +158,12 @@ packages:
   '@astrojs/rss@4.0.11':
     resolution: {integrity: sha512-3e3H8i6kc97KGnn9iaZBJpIkdoQi8MmR5zH5R+dWsfCM44lLTszOqy1OBfGGxDt56mpQkYVtZJWoxMyWuUZBfw==}
 
-  '@astrojs/svelte@5.7.3':
-    resolution: {integrity: sha512-0PAwn2KLVpGsJppG8dWM1P9+/VrjAdhMWgEgwC1PjY2xFG565bTw7OuGaS5zh5Fu4AcjVoBkVQKjW/N3mLnrJA==}
-    engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
+  '@astrojs/svelte@7.0.4':
+    resolution: {integrity: sha512-vTFhHhYNr1GkrpR63Talv8ba1HHUWoHNzBs4eJNZz4bQCihAdxw+xz/CWcWM1bfAzH3Jfc7jAKXPNAZSwN4oFg==}
+    engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
     peerDependencies:
-      astro: ^4.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.190
+      astro: ^5.0.0
+      svelte: ^5.1.16
       typescript: ^5.3.3
 
   '@astrojs/telemetry@3.2.0':
@@ -698,10 +694,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@jridgewell/gen-mapping@0.3.5':
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -868,20 +860,20 @@ packages:
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0':
-    resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
-    engines: {node: ^18.0.0 || >=20}
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
-  '@sveltejs/vite-plugin-svelte@3.1.2':
-    resolution: {integrity: sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==}
-    engines: {node: ^18.0.0 || >=20}
+  '@sveltejs/vite-plugin-svelte@5.0.3':
+    resolution: {integrity: sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -894,9 +886,6 @@ packages:
 
   '@types/eslint__js@8.42.3':
     resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
-
-  '@types/estree@1.0.5':
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1124,10 +1113,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.12.1:
-    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
+  acorn-typescript@1.4.13:
+    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
+    peerDependencies:
+      acorn: '>=8.9.0'
 
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
@@ -1168,9 +1157,6 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
-  aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1291,9 +1277,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  code-red@1.0.4:
-    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1340,10 +1323,6 @@ packages:
 
   crossws@0.3.3:
     resolution: {integrity: sha512-/71DJT3xJlqSnBr83uGJesmVHSzZEvgxHt/fIKxBAAngqMHmnBWQNxCphVxxJ2XL3xleu5+hJD6IQ3TglBedcw==}
-
-  css-tree@2.3.1:
-    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -1499,6 +1478,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1511,6 +1493,9 @@ packages:
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
+
+  esrap@1.4.3:
+    resolution: {integrity: sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -1757,8 +1742,8 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-reference@3.0.2:
-    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -1853,9 +1838,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  magic-string@0.30.11:
-    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -1903,9 +1885,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdn-data@2.0.30:
-    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
@@ -2132,9 +2111,6 @@ packages:
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
-
-  periscopic@3.1.0:
-    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -2405,21 +2381,15 @@ packages:
       chart.js: ^3.5.0 || ^4.0.0
       svelte: ^4.0.0
 
-  svelte-hmr@0.16.0:
-    resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
-    engines: {node: ^12.20 || ^14.13.1 || >= 16}
-    peerDependencies:
-      svelte: ^3.19.0 || ^4.0.0
-
   svelte2tsx@0.7.34:
     resolution: {integrity: sha512-WTMhpNhFf8/h3SMtR5dkdSy2qfveomkhYei/QW9gSPccb0/b82tjHvLop6vT303ZkGswU/da1s6XvrLgthQPCw==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@4.2.19:
-    resolution: {integrity: sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==}
-    engines: {node: '>=16'}
+  svelte@5.19.5:
+    resolution: {integrity: sha512-vVAntseegJX80sgbY8CxQISSE/VoDSfP7VZHoQaf2+z+2XOPOz/N+k455HJmO9O0g8oxTtuE0TBhC/5LAP4lPg==}
+    engines: {node: '>=18'}
 
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
@@ -2673,14 +2643,6 @@ packages:
       yaml:
         optional: true
 
-  vitefu@0.2.5:
-    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
   vitefu@1.0.5:
     resolution: {integrity: sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==}
     peerDependencies:
@@ -2887,6 +2849,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  zimmerframe@1.1.2:
+    resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
+
   zod-to-json-schema@3.24.1:
     resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
     peerDependencies:
@@ -2905,11 +2870,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@ampproject/remapping@2.2.1':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -2999,16 +2959,27 @@ snapshots:
       fast-xml-parser: 4.5.0
       kleur: 4.1.5
 
-  '@astrojs/svelte@5.7.3(astro@5.1.10(@types/node@22.10.10)(jiti@2.4.2)(rollup@4.27.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0))(svelte@4.2.19)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))':
+  '@astrojs/svelte@7.0.4(@types/node@22.10.10)(astro@5.1.10(@types/node@22.10.10)(jiti@2.4.2)(rollup@4.27.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0))(jiti@2.4.2)(svelte@5.19.5)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
       astro: 5.1.10(@types/node@22.10.10)(jiti@2.4.2)(rollup@4.27.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.5.0)
-      svelte: 4.2.19
-      svelte2tsx: 0.7.34(svelte@4.2.19)(typescript@5.7.3)
+      svelte: 5.19.5
+      svelte2tsx: 0.7.34(svelte@5.19.5)(typescript@5.7.3)
       typescript: 5.7.3
+      vite: 6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)
     transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
       - supports-color
-      - vite
+      - terser
+      - tsx
+      - yaml
 
   '@astrojs/telemetry@3.2.0':
     dependencies:
@@ -3386,12 +3357,6 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@jridgewell/gen-mapping@0.3.5':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -3528,26 +3493,25 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.1': {}
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)))(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)))(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
       debug: 4.4.0
-      svelte: 4.2.19
+      svelte: 5.19.5
       vite: 6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)))(svelte@4.2.19)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)))(svelte@5.19.5)(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
-      svelte: 4.2.19
-      svelte-hmr: 0.16.0(svelte@4.2.19)
+      svelte: 5.19.5
       vite: 6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)
-      vitefu: 0.2.5(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
+      vitefu: 1.0.5(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -3565,8 +3529,6 @@ snapshots:
   '@types/eslint__js@8.42.3':
     dependencies:
       '@types/eslint': 9.6.0
-
-  '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.6': {}
 
@@ -3954,7 +3916,9 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
-  acorn@8.12.1: {}
+  acorn-typescript@1.4.13(acorn@8.14.0):
+    dependencies:
+      acorn: 8.14.0
 
   acorn@8.14.0: {}
 
@@ -3996,10 +3960,6 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
-
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -4216,14 +4176,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  code-red@1.0.4:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.6
-      acorn: 8.14.0
-      estree-walker: 3.0.3
-      periscopic: 3.1.0
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4265,11 +4217,6 @@ snapshots:
   crossws@0.3.3:
     dependencies:
       uncrypto: 0.1.3
-
-  css-tree@2.3.1:
-    dependencies:
-      mdn-data: 2.0.30
-      source-map-js: 1.2.0
 
   css-tree@3.1.0:
     dependencies:
@@ -4469,6 +4416,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.3.0:
     dependencies:
       acorn: 8.14.0
@@ -4480,6 +4429,10 @@ snapshots:
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@1.4.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -4766,7 +4719,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-reference@3.0.2:
+  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
 
@@ -4849,10 +4802,6 @@ snapshots:
       tslib: 2.8.1
 
   lru-cache@10.4.3: {}
-
-  magic-string@0.30.11:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.17:
     dependencies:
@@ -4983,8 +4932,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.2
-
-  mdn-data@2.0.30: {}
 
   mdn-data@2.12.2: {}
 
@@ -5316,12 +5263,6 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
-  periscopic@3.1.0:
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 3.0.3
-      is-reference: 3.0.2
-
   picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
@@ -5373,10 +5314,10 @@ snapshots:
       prettier: 3.4.2
       sass-formatter: 0.7.6
 
-  prettier-plugin-svelte@3.3.3(prettier@3.4.2)(svelte@4.2.19):
+  prettier-plugin-svelte@3.3.3(prettier@3.4.2)(svelte@5.19.5):
     dependencies:
       prettier: 3.4.2
-      svelte: 4.2.19
+      svelte: 5.19.5
 
   prettier@2.8.7:
     optional: true
@@ -5658,38 +5599,34 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-chartjs@3.1.5(chart.js@4.4.7)(svelte@4.2.19):
+  svelte-chartjs@3.1.5(chart.js@4.4.7)(svelte@5.19.5):
     dependencies:
       chart.js: 4.4.7
-      svelte: 4.2.19
+      svelte: 5.19.5
 
-  svelte-hmr@0.16.0(svelte@4.2.19):
-    dependencies:
-      svelte: 4.2.19
-
-  svelte2tsx@0.7.34(svelte@4.2.19)(typescript@5.7.3):
+  svelte2tsx@0.7.34(svelte@5.19.5)(typescript@5.7.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 4.2.19
+      svelte: 5.19.5
       typescript: 5.7.3
 
-  svelte@4.2.19:
+  svelte@5.19.5:
     dependencies:
-      '@ampproject/remapping': 2.2.1
+      '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-      '@types/estree': 1.0.5
-      acorn: 8.12.1
-      aria-query: 5.3.0
+      '@types/estree': 1.0.6
+      acorn: 8.14.0
+      acorn-typescript: 1.4.13(acorn@8.14.0)
+      aria-query: 5.3.2
       axobject-query: 4.1.0
-      code-red: 1.0.4
-      css-tree: 2.3.1
-      estree-walker: 3.0.3
-      is-reference: 3.0.2
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.3
+      is-reference: 3.0.3
       locate-character: 3.0.0
-      magic-string: 0.30.11
-      periscopic: 3.1.0
+      magic-string: 0.30.17
+      zimmerframe: 1.1.2
 
   synckit@0.9.2:
     dependencies:
@@ -5904,10 +5841,6 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.5.0
 
-  vitefu@0.2.5(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)):
-    optionalDependencies:
-      vite: 6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)
-
   vitefu@1.0.5(vite@6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)):
     optionalDependencies:
       vite: 6.0.11(@types/node@22.10.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.5.0)
@@ -6112,6 +6045,8 @@ snapshots:
       yoctocolors: 2.1.1
 
   yoctocolors@2.1.1: {}
+
+  zimmerframe@1.1.2: {}
 
   zod-to-json-schema@3.24.1(zod@3.24.1):
     dependencies:

--- a/src/components/RankChart.svelte
+++ b/src/components/RankChart.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
-  import { Bar } from "svelte-chartjs";
   import {
     Chart as ChartJS,
     CategoryScale,
+    BarController,
     LinearScale,
     BarElement,
   } from "chart.js";
   import type { ChartData, ChartOptions } from "chart.js";
   import type { ProcessedArticle } from "@/lib/article";
+  import { onMount } from "svelte";
 
-  ChartJS.register(CategoryScale, LinearScale, BarElement);
+  let canvas: HTMLCanvasElement | undefined;
 
   /** published な記事のみを抽出 */
   export let articles: ProcessedArticle<true>[];
@@ -138,10 +139,31 @@
       },
     },
   } as const satisfies ChartOptions<"bar">;
+
+  // グラフの描画
+  onMount(() => {
+    // Register the custom scales and elements
+    ChartJS.register(CategoryScale, LinearScale, BarElement, BarController);
+
+    const ctx = canvas?.getContext("2d");
+    if (ctx == null) {
+      return;
+    }
+
+    const chart = new ChartJS(ctx, {
+      type: "bar",
+      data,
+      options,
+    });
+
+    // グラフの破棄
+    return () => {
+      chart.destroy();
+      ChartJS.unregister(BarController, BarElement, LinearScale, CategoryScale);
+    };
+  });
 </script>
 
 <div id="rankings-container" class="w-[90vw] max-w-3xl px-1">
-  <div>
-    <Bar {data} {options} height={600} />
-  </div>
+  <canvas bind:this={canvas} id="myChart" height={600} />
 </div>

--- a/src/components/RankChart.svelte
+++ b/src/components/RankChart.svelte
@@ -13,7 +13,10 @@
   let canvas: HTMLCanvasElement | undefined;
 
   /** published な記事のみを抽出 */
-  export let articles: ProcessedArticle<true>[];
+  type Props = {
+    articles: ProcessedArticle<true>[];
+  };
+  const { articles }: Props = $props();
 
   // GitHubユーザーごとの記事数をカウント
   const userCounts: { [user: string]: number } = {};
@@ -165,5 +168,6 @@
 </script>
 
 <div id="rankings-container" class="w-[90vw] max-w-3xl px-1">
+  <!-- svelte-ignore element_invalid_self_closing_tag -->
   <canvas bind:this={canvas} id="myChart" height={600} />
 </div>

--- a/src/components/RankChart/RankChart.svelte
+++ b/src/components/RankChart/RankChart.svelte
@@ -6,145 +6,22 @@
     LinearScale,
     BarElement,
   } from "chart.js";
-  import type { ChartData, ChartOptions } from "chart.js";
-  import type { ProcessedArticle } from "@/lib/article";
+  import { getData, getOptions, getRanking } from "./utils.js";
+  import type { Article } from "./types.js";
 
   let canvas: HTMLCanvasElement | undefined;
 
   /** published な記事のみを抽出 */
   type Props = {
-    articles: ProcessedArticle<true>[];
+    articles: Article[];
   };
   const { articles }: Props = $props();
 
   /** ランキングを計算し、1つの配列にまとめる */
-  const ranking = $derived.by(() => {
-    /** GitHubユーザーごとの記事数をカウント */
-    const userCounts: { [user: string]: number } = {};
-    articles.forEach((article) => {
-      const user = article.githubUser;
-      if (userCounts[user]) {
-        userCounts[user]++;
-      } else {
-        userCounts[user] = 1;
-      }
-    });
+  const ranking = $derived(getRanking(articles));
 
-    /** 同率のユーザーをグループ化 */
-    const groupedUsers: { [count: number]: { users: string[] } } = {};
-    Object.entries(userCounts).forEach(([user, count]) => {
-      if (!groupedUsers[count]) {
-        groupedUsers[count] = { users: [] };
-      }
-      groupedUsers[count].users.push(user);
-    });
-
-    const userRankings: { user: string; articleCount: number; rank: number }[] =
-      [];
-    let rank = 1;
-    Object.keys(groupedUsers)
-      .map(Number)
-      .sort((a, b) => b - a)
-      .forEach((count) => {
-        const users = groupedUsers[count].users;
-        users.forEach((user) => {
-          userRankings.push({ user, articleCount: count, rank });
-        });
-        rank += users.length;
-      });
-
-    return userRankings.filter(({ rank }) => rank <= 10);
-  });
-
-  const rankingTick = $derived.by(() => {
-    const longestUsername = Math.max(...ranking.map(({ user }) => user.length));
-
-    return ranking.map(({ user, rank }) => {
-      // FIXME: 左揃えにする方法がわからなかった
-      const padding = " ".repeat(longestUsername - user.length);
-      return `${rank}. ${user}${padding}`;
-    });
-  });
-
-  const data = $derived({
-    labels: rankingTick,
-    datasets: [
-      {
-        label: "記事数",
-        data: ranking.map(({ articleCount }) => articleCount),
-        barThickness: 12,
-        backgroundColor: (ctx) => {
-          const rank = ranking[ctx.dataIndex].rank;
-          switch (rank) {
-            case 1:
-              return "#FFD700";
-            case 2:
-              return "#C0C0C0";
-            case 3:
-              return "#C47222";
-            default:
-              return "#6cb26a";
-          }
-        },
-        borderRadius: 5,
-        borderWidth: 0,
-        barPercentage: 0.5,
-      },
-    ],
-  } as const satisfies ChartData<"bar">);
-
-  const options = {
-    indexAxis: "y",
-    // Elements options apply to all of the options unless overridden in a dataset
-    // In this case, we are setting the border of each horizontal bar to be 2px wide
-    elements: {
-      bar: {
-        borderWidth: 2,
-      },
-    },
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        display: false,
-      },
-      title: {
-        display: false,
-      },
-    },
-    onClick: function (_, items) {
-      if (items.length > 0) {
-        const item = items[0];
-        if (data.labels === null || data.labels![item.index] === null) return;
-        const labelText = data.labels![item.index] + "";
-
-        const matched = /^\d+\.\s+(\S+)/.exec(labelText);
-        if (matched === null) return;
-        const githubUser = matched[1];
-        window.location.href = `/ekiden/runners/${githubUser}/`;
-      }
-    },
-    scales: {
-      x: {
-        ticks: {
-          stepSize: 1,
-        },
-      },
-      y: {
-        ticks: {
-          autoSkip: false,
-          padding: 4,
-          font: {
-            size: 16,
-            family: "monospace",
-          },
-        },
-        grid: {
-          display: false,
-        },
-      },
-    },
-  } as const satisfies ChartOptions<"bar">;
+  const data = $derived(getData(ranking));
+  const options = $derived(getOptions(data));
 
   // effect が実行される前に Chart.js のカスタムスケールと要素を登録
   $effect.pre(() => {

--- a/src/components/RankChart/RankChart.svelte
+++ b/src/components/RankChart/RankChart.svelte
@@ -8,7 +8,6 @@
   } from "chart.js";
   import type { ChartData, ChartOptions } from "chart.js";
   import type { ProcessedArticle } from "@/lib/article";
-  import { onMount } from "svelte";
 
   let canvas: HTMLCanvasElement | undefined;
 
@@ -147,11 +146,19 @@
     },
   } as const satisfies ChartOptions<"bar">;
 
-  // グラフの描画
-  onMount(() => {
+  // effect が実行される前に Chart.js のカスタムスケールと要素を登録
+  $effect.pre(() => {
     // Register the custom scales and elements
     ChartJS.register(CategoryScale, LinearScale, BarElement, BarController);
 
+    // Unregister the custom scales and elements
+    return () => {
+      ChartJS.unregister(BarController, BarElement, LinearScale, CategoryScale);
+    };
+  });
+
+  // グラフの描画。jsが読み込まれた後に実行される。
+  $effect(() => {
     const ctx = canvas?.getContext("2d");
     if (ctx == null) {
       return;
@@ -166,7 +173,6 @@
     // グラフの破棄
     return () => {
       chart.destroy();
-      ChartJS.unregister(BarController, BarElement, LinearScale, CategoryScale);
     };
   });
 </script>

--- a/src/components/RankChart/RankChart.svelte
+++ b/src/components/RankChart/RankChart.svelte
@@ -8,6 +8,7 @@
   } from "chart.js";
   import { getData, getOptions, getRanking } from "./utils.js";
   import type { Article } from "./types.js";
+  import { onMount } from "svelte";
 
   let canvas: HTMLCanvasElement | undefined;
 
@@ -24,7 +25,7 @@
   const options = $derived(getOptions(data));
 
   // effect が実行される前に Chart.js のカスタムスケールと要素を登録
-  $effect.pre(() => {
+  onMount(() => {
     // Register the custom scales and elements
     ChartJS.register(CategoryScale, LinearScale, BarElement, BarController);
 

--- a/src/components/RankChart/index.ts
+++ b/src/components/RankChart/index.ts
@@ -1,0 +1,1 @@
+export { default as RankChart } from "./RankChart.svelte";

--- a/src/components/RankChart/types.ts
+++ b/src/components/RankChart/types.ts
@@ -1,0 +1,9 @@
+import type { ProcessedArticle } from "@/lib/article";
+
+export type Ranking = {
+  user: string;
+  articleCount: number;
+  rank: number;
+};
+
+export type Article = ProcessedArticle<true>;

--- a/src/components/RankChart/utils.ts
+++ b/src/components/RankChart/utils.ts
@@ -1,0 +1,141 @@
+import type { ChartData, ChartOptions } from "chart.js";
+import type { Article, Ranking } from "./types";
+
+/**
+ * ランキングを計算し、1つの配列にまとめる
+ */
+export function getRanking(articles: Article[]): Ranking[] {
+  /** GitHubユーザーごとの記事数をカウント */
+  const userCounts: { [user: string]: number } = {};
+  articles.forEach((article) => {
+    const user = article.githubUser;
+    if (userCounts[user]) {
+      userCounts[user]++;
+    } else {
+      userCounts[user] = 1;
+    }
+  });
+
+  /** 同率のユーザーをグループ化 */
+  const groupedUsers: { [count: number]: { users: string[] } } = {};
+  Object.entries(userCounts).forEach(([user, count]) => {
+    if (!groupedUsers[count]) {
+      groupedUsers[count] = { users: [] };
+    }
+    groupedUsers[count].users.push(user);
+  });
+
+  const userRankings: Ranking[] = [];
+  let rank = 1;
+  Object.keys(groupedUsers)
+    .map(Number)
+    .sort((a, b) => b - a)
+    .forEach((count) => {
+      const users = groupedUsers[count].users;
+      users.forEach((user) => {
+        userRankings.push({ user, articleCount: count, rank });
+      });
+      rank += users.length;
+    });
+
+  return userRankings.filter(({ rank }) => rank <= 10);
+}
+
+/**
+ * getOptions returns the options for the bar chart.
+ */
+export function getOptions(data: ChartData<"bar">) {
+  return {
+    indexAxis: "y",
+    // Elements options apply to all of the options unless overridden in a dataset
+    // In this case, we are setting the border of each horizontal bar to be 2px wide
+    elements: {
+      bar: {
+        borderWidth: 2,
+      },
+    },
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false,
+      },
+      title: {
+        display: false,
+      },
+    },
+    onClick: function (_, items) {
+      if (items.length > 0) {
+        const item = items[0];
+        if (data.labels === null || data.labels![item.index] === null) return;
+        const labelText = data.labels![item.index] + "";
+
+        const matched = /^\d+\.\s+(\S+)/.exec(labelText);
+        if (matched === null) return;
+        const githubUser = matched[1];
+        window.location.href = `/ekiden/runners/${githubUser}/`;
+      }
+    },
+    scales: {
+      x: {
+        ticks: {
+          stepSize: 1,
+        },
+      },
+      y: {
+        ticks: {
+          autoSkip: false,
+          padding: 4,
+          font: {
+            size: 16,
+            family: "monospace",
+          },
+        },
+        grid: {
+          display: false,
+        },
+      },
+    },
+  } as const satisfies ChartOptions<"bar">;
+}
+
+/**
+ * getData returns the data for the bar chart.
+ */
+export function getData(ranking: Ranking[]) {
+  /** find the longest username */
+  const longestUsername = Math.max(...ranking.map(({ user }) => user.length));
+
+  const rankingTick = ranking.map(({ user, rank }) => {
+    // FIXME: 左揃えにする方法がわからなかった
+    const padding = " ".repeat(longestUsername - user.length);
+    return `${rank}. ${user}${padding}`;
+  });
+
+  return {
+    labels: rankingTick,
+    datasets: [
+      {
+        label: "記事数",
+        data: ranking.map(({ articleCount }) => articleCount),
+        barThickness: 12,
+        backgroundColor: (ctx) => {
+          const rank = ranking[ctx.dataIndex].rank;
+          switch (rank) {
+            case 1:
+              return "#FFD700";
+            case 2:
+              return "#C0C0C0";
+            case 3:
+              return "#C47222";
+            default:
+              return "#6cb26a";
+          }
+        },
+        borderRadius: 5,
+        borderWidth: 0,
+        barPercentage: 0.5,
+      },
+    ],
+  } as const satisfies ChartData<"bar">;
+}

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -47,6 +47,6 @@ const articles = getArticles({ isPublished: true }).filter((article) => {
   />
   <section class="py-4">
     <h2>記事投稿数ランキング（{displaySectionName(section)}）</h2>
-    <RankChart articles={articles} client:only="svelte" />
+    <RankChart articles={articles} client:visible />
   </section>
 </Base>

--- a/src/pages/ranking/[section].astro
+++ b/src/pages/ranking/[section].astro
@@ -9,7 +9,7 @@ import SeasonList, {
 } from "@/components/SeasonList.astro";
 import { getArticles } from "@/lib/article";
 import Base from "@/layouts/Base.astro";
-import RankChart from "@/components/RankChart.svelte";
+import { RankChart } from "@/components/RankChart";
 
 export function getStaticPaths() {
   return getSectionArray(false).map((section) => ({

--- a/src/pages/ranking/index.astro
+++ b/src/pages/ranking/index.astro
@@ -14,6 +14,6 @@ const articles = getArticles({ isPublished: true });
     <h2 class="mb-2 mt-4 text-2xl font-bold font-ekiden-heading">
       記事投稿数ランキング（総合）
     </h2>
-    <RankChart articles={articles} client:only="svelte" />
+    <RankChart articles={articles} client:visible />
   </section>
 </Base>

--- a/src/pages/ranking/index.astro
+++ b/src/pages/ranking/index.astro
@@ -1,7 +1,7 @@
 ---
 import Base from "@/layouts/Base.astro";
 import SeasonList from "@/components/SeasonList.astro";
-import RankChart from "@/components/RankChart.svelte";
+import { RankChart } from "@/components/RankChart";
 import { getArticles } from "@/lib/article";
 
 const articles = getArticles({ isPublished: true });


### PR DESCRIPTION
rankingのグラフが表示されていなかったので修正
~~`client:only='svelte`じゃなくなった？教えて詳しい人！ (多分 @staticWagomU さん詳しそう~~

本来ならば個別のPRに分けるべきですが、一気にやってしまいました

- svelte-chartjsがメンテされていないので依存から排除。直接chatjsを叩きます
- svelte5に移行
- Componentのfileの行数が長く見通しが悪いため、データ整形の関数を別fileに逃しました