### PR TITLE
pxを用いたclass指定をやめて、tailwind標準の数値によるサイズ指定を行う

### DIFF
--- a/src/components/ArticleMonth.astro
+++ b/src/components/ArticleMonth.astro
@@ -4,18 +4,18 @@ type Props = { month: number };
 const { month } = Astro.props;
 ---
 
-<div class="px-[16px]">
+<div class="p-4">
   <div class="w-full flex flex-row flex-nowrap">
-    <div class="w-[48px]"></div>
-    <div class="h-[16px] w-[24px] bg-ekiden-green-500"></div>
+    <div class="w-12"></div>
+    <div class="h-4 w-6 bg-ekiden-green-500"></div>
   </div>
   <div
-    class="w-[120px] border border-ekiden-green-500 rounded p-1 text-center align-middle text-ekiden-green-500 font-bold"
+    class="w-30 border border-ekiden-green-500 rounded p-1 text-center align-middle text-ekiden-green-500 font-bold"
   >
     {month}月
   </div>
   <div class="w-full flex flex-row flex-nowrap">
-    <div class="w-[48px]"></div>
-    <div class="h-[16px] w-[24px] bg-ekiden-green-500"></div>
+    <div class="w-12"></div>
+    <div class="h-4 w-6 bg-ekiden-green-500"></div>
   </div>
 </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,7 +32,7 @@ const { slug } = Astro.props;
   >
     <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"
       ><img
-        class="max-h-[31px] max-w-[88px] min-h-[31px] min-w-[88px] border-0"
+        class="max-h-7.75 max-w-22 min-h-7.75 min-w-22 border-0"
         alt="クリエイティブ・コモンズ・ライセンス"
         src="https://i.creativecommons.org/l/by/4.0/88x31.png"
       /></a

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,7 +32,7 @@ const { slug } = Astro.props;
   >
     <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"
       ><img
-        class="max-h-7.75 max-w-22 min-h-7.75 min-w-22 border-0"
+        class="max-h-[31px] max-w-[88px] min-h-[31px] min-w-[88px] border-0"
         alt="クリエイティブ・コモンズ・ライセンス"
         src="https://i.creativecommons.org/l/by/4.0/88x31.png"
       /></a

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const { slug } = Astro.props;
           src={logoImage}
           formats={["avif", "webp"]}
           alt="Vim-JP"
-          class="h-[64px] w-[64px]"
+          class="h-16 w-16"
         />
         Vim駅伝
       </a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const { slug } = Astro.props;
           src={logoImage}
           formats={["avif", "webp"]}
           alt="Vim-JP"
-          class="h-16 w-16"
+          class="size-16"
         />
         Vim駅伝
       </a>


### PR DESCRIPTION
このプルリクエストには、スタイリングを単純化し標準化するために、複数のコンポーネントのCSSクラスにいくつかの変更が含まれています。最も重要な変更は `ArticleMonth`、`Footer`、`Header` コンポーネントの更新です。

スタイリングの更新

* [`src/components/ArticleMonth.astro`](diffhunk://#diff-31ed6df4300cbf0ee72875c0791cf8ad8b0c0a057e927f6adaefd539f3b34ec1L7-R19): 特定のピクセル値をTailwind CSSユーティリティクラスに置き換えることで、paddingとwidthクラスを簡素化。
* [`src/components/Footer.astro`](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L35-R35): Tailwind CSSユーティリティクラスを使用したライセンス画像の寸法を更新し、一貫性を持たせた。
* [`src/components/Header.astro`](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beL24-R24): 特定の高さと幅のクラスを、ロゴ画像用の単一のユーティリティ・クラスに置き換えた。


