### PR TITLE
refactor(Footer.astro): `shrink-0`を用いることでクリエイティブ・コモンズの画像にサイズを指定せずに画像を等倍で表示する

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,6 +39,8 @@ const { slug } = Astro.props;
         class="border-0"
         alt="クリエイティブ・コモンズ・ライセンス"
         src="https://i.creativecommons.org/l/by/4.0/88x31.png"
+        width={88}
+        height={31}
       />
     </a>
     <div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,13 +30,17 @@ const { slug } = Astro.props;
   <div
     class="mx-auto max-w-screen-lg flex flex-row items-center gap-2 px-3 py-2 align-middle"
   >
-    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"
-      ><img
-        class="max-h-[31px] max-w-[88px] min-h-[31px] min-w-[88px] border-0"
+    <a
+      rel="license"
+      href="http://creativecommons.org/licenses/by/4.0/"
+      class="shrink-0"
+    >
+      <img
+        class="border-0"
         alt="クリエイティブ・コモンズ・ライセンス"
         src="https://i.creativecommons.org/l/by/4.0/88x31.png"
-      /></a
-    >
+      />
+    </a>
     <div>
       この 作品 は <a
         rel="license"


### PR DESCRIPTION

ここをpxで指定していたのはおそらく画像が意図せず小さくなってしまっていたからだと推測
なので、画像をshrinkさせないように修正

参考: https://github.com/vim-jp/ekiden/pull/856#discussion_r1934788264
参考: https://tailwindcss.com/docs/flex-shrink#preventing-items-from-shrinking
