### PR TITLE
fix padding at ArticleMonth component

### DIFF
--- a/src/components/ArticleMonth.astro
+++ b/src/components/ArticleMonth.astro
@@ -4,7 +4,7 @@ type Props = { month: number };
 const { month } = Astro.props;
 ---
 
-<div class="p-4">
+<div class="px-4 pd-0">
   <div class="w-full flex flex-row flex-nowrap">
     <div class="w-12"></div>
     <div class="h-4 w-6 bg-ekiden-green-500"></div>

--- a/src/components/ArticleMonth.astro
+++ b/src/components/ArticleMonth.astro
@@ -4,7 +4,7 @@ type Props = { month: number };
 const { month } = Astro.props;
 ---
 
-<div class="px-4 pd-0">
+<div class="px-4">
   <div class="w-full flex flex-row flex-nowrap">
     <div class="w-12"></div>
     <div class="h-4 w-6 bg-ekiden-green-500"></div>


### PR DESCRIPTION
駅伝のトップ画面のx月の上下にあったの謎のpaddingを直しました

before
![image](https://github.com/user-attachments/assets/ad5e1f6a-512b-4e5a-8088-679d288409cb)

after
![image](https://github.com/user-attachments/assets/d19ef018-d45d-4c78-a9ca-a25b6a7377a5)