### PR TITLE
feat: put a link for the repository on the header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,8 +36,13 @@ const { slug } = Astro.props;
       <PageLink slug={slug} href="/ranking/">ランキング</PageLink>
       <PageLink slug={slug} href="/statistics/">統計</PageLink>
     </nav>
-    <div>
+    <div class="flex-gap flex flex-row items-center gap-4">
       <ConversionButton href="/ekiden/#first-slot" />
+      <a href="https://github.com/vim-jp/ekiden">
+        <div class="flex flex-row items-center">
+          <span i-radix-icons-github-logo w-7 h-7></span>
+        </div>
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
before: ![image](https://github.com/user-attachments/assets/be24114d-8df7-48d7-a2f9-9bb31224eb53)
after: ![image](https://github.com/user-attachments/assets/9033b2b2-cfd0-496a-9233-2abf738ec6f8)

As a just idea.
I am a little doubtful that this is solution for the problem.

for: vim-jp/ekiden#908
