### PR TITLE
pnpm周りを修正

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-manage-package-manager-versions=true
-use-node-version=22.11.0
-@jsr:registry=https://npm.jsr.io

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@eslint/js": "^9.25.0",
     "@iconify-json/radix-icons": "^1.2.2",
     "@iconify-json/tabler": "^1.2.17",
-    "@std/collections": "npm:@jsr/std__collections@^1.0.6",
+    "@std/collections": "jsr:^1.0.6",
     "@types/eslint__js": "^9.14.0",
     "@types/node": "^22.14.1",
     "@typescript-eslint/utils": "^8.30.1",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,5 @@
     "vitest": "^3.1.2"
   },
   "private": true,
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
+  "packageManager": "pnpm@10.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         specifier: ^1.2.17
         version: 1.2.17
       '@std/collections':
-        specifier: npm:@jsr/std__collections@^1.0.6
+        specifier: jsr:^1.0.6
         version: '@jsr/std__collections@1.0.9'
       '@types/eslint__js':
         specifier: ^9.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
 useNodeVersion: 22.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+useNodeVersion: 22.14.0


### PR DESCRIPTION
- pnpmのバージョンを10.10.0にアップ
- 新しいpnpmではinstall時のbuildを明示的に許可する必要があるのでそれを追加
- 使うnodeのバージョンを22.14.0にし、`.npmrc`ではなく`pnpm-workspace.yaml`に定義するよう変更
- jsrパッケージをpnpmのnative supportに準拠した方法で記述