### PR TITLE
chore: update pnpm and use devEngines.runtime to manage node runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,6 @@
     "prettier:fix": "prettier --cache --write --plugin-search-dir=. src",
     "preinstall": "npx only-allow pnpm"
   },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": "^22.14.0",
-      "onFail": "download"
-    }
-  },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/rss": "^4.0.11",
@@ -65,5 +58,12 @@
     "vitest": "^3.1.2"
   },
   "private": true,
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.15.0",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.14.0",
+      "onFail": "download"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
     "prettier:fix": "prettier --cache --write --plugin-search-dir=. src",
     "preinstall": "npx only-allow pnpm"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.14.0",
+      "onFail": "download"
+    }
+  },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/rss": "^4.0.11",
@@ -58,5 +65,5 @@
     "vitest": "^3.1.2"
   },
   "private": true,
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.15.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-plugin-astro:
         specifier: ^1.3.1
         version: 1.3.1(eslint@9.33.0(jiti@2.5.1))
+      node:
+        specifier: runtime:^22.14.0
+        version: runtime:22.18.0
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -2424,6 +2427,115 @@ packages:
 
   node-mock-http@1.0.2:
     resolution: {integrity: sha512-zWaamgDUdo9SSLw47we78+zYw/bDr5gH8pH7oRRs8V3KmBtu8GLgGIbV2p/gRPd3LWpEOpjQj7X1FOU3VFMJ8g==}
+
+  node@runtime:22.18.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-e7da8wj8n2PlaJaODvDhYAuxBavi0q+ZIXrHLpok/9A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-LBKRPLpnr3fe2KOZ3z/ZHC5/hijHB52kC7n/M78A38A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-nIqh5f9XgLOMwRNOImPYTi9DCOuEwCUV468zk2ygLNw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-1BXu6pCi/bYMZt04ayWKy/xNH6RyCo313qc2n7283e4=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-V4MJFFgdw2QOjZU3i3bGkQhg9CUxlZ5OiOtEXgzZgrA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-OPlly6pecw29Oxr+iVz9uG2pY3FHSCfQXYR9M4oMnJc=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-81eLDnzfJHBF9u63Zv69dJQpVDUhYRAstgQKTUw7TDw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-oucDcl2Gg76Gu12pZ7+CcvRRi9rxDyE4nissnq6ujIo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-Ajr7PSXEx9EMtuuKZIZcNHtW1LB+ZpBgbQIRMKkZImM=
+            prefix: node-v22.18.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-yV2KfhyZ5mnMCMnxF24GjB9QhHw3kI/LjDW2JII2ZRE=
+            prefix: node-v22.18.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-8uVGNF9ynY6CyCoIjmFudt8UMwxT08/su6tR94PwjPQ=
+            prefix: node-v22.18.0-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.18.0/node-v22.18.0-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.18.0
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5992,6 +6104,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-mock-http@1.0.2: {}
+
+  node@runtime:22.18.0: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 onlyBuiltDependencies:
   - esbuild
   - sharp
-useNodeVersion: 22.14.0


### PR DESCRIPTION
https://pnpm.io/package_json#devenginesruntime
`devEngine.runtime`でnodeのランタイムを管理するようにしました。
- より標準の方法
- lockfileにnodeのバージョンが記載される
などのメリットがあります