### PR TITLE
Update README to link to about page instead of first article

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 「Vim 駅伝」とは、Vim に関する記事を持ち回りで執筆する企画です。
 本リポジトリは「Vim 駅伝」の参加記事や執筆スケジュールなどを記載する案内ページを管理するものです。
 
-参加方法はVim駅伝[初日の記事](https://thinca.hatenablog.com/entry/vim-ekiden-is-launched)をご覧ください。
+参加方法など、詳細はVim 駅伝の[アバウトページ](https://vim-jp.org/ekiden/about/)をご覧ください。
 
 サイトの構成は [Astro](https://astro.build) を用いて行っています。
 ローカルでのビルド方法は Astro の公式ドキュメントに従ってください。


### PR DESCRIPTION
#1456 の一部を別PRとして対応
> また、リポジトリのREADMEの参加方法も初日の記事へのリンクになっており、正式な参加方法ページに更新した方が良い