### PR TITLE
chore(security): Set cooldown to dependabot, avoiding supply-chain attack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Supply Chain攻撃への対策としてdependabotの自動更新を3日待つように設定します
c.f. https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
